### PR TITLE
[D-1] 오늘 탭 화면 구성

### DIFF
--- a/Alarmi/Alarmi.xcodeproj/project.pbxproj
+++ b/Alarmi/Alarmi.xcodeproj/project.pbxproj
@@ -15,7 +15,6 @@
 		EFF8D2BB28819D03005A4D10 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D2BA28819D03005A4D10 /* UIViewController+.swift */; };
 		EFF8D2A628810A11005A4D10 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D2A528810A11005A4D10 /* UIView+.swift */; };
 		EFF8D2AA28811A7F005A4D10 /* UIStackView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D2A928811A7F005A4D10 /* UIStackView+.swift */; };
-		EFF8D2B92881982A005A4D10 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D2B82881982A005A4D10 /* UIViewController+.swift */; };
 		EFFD73EF287BC77D00D9F267 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFFD73EE287BC77D00D9F267 /* AppDelegate.swift */; };
 		EFFD73F1287BC77D00D9F267 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFFD73F0287BC77D00D9F267 /* SceneDelegate.swift */; };
 		EFFD73F3287BC77D00D9F267 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFFD73F2287BC77D00D9F267 /* ViewController.swift */; };
@@ -53,7 +52,6 @@
 		EFF8D2BA28819D03005A4D10 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		EFF8D2A528810A11005A4D10 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		EFF8D2A928811A7F005A4D10 /* UIStackView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+.swift"; sourceTree = "<group>"; };
-		EFF8D2B82881982A005A4D10 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		EFFD73EB287BC77D00D9F267 /* Alarmi.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Alarmi.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EFFD73EE287BC77D00D9F267 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		EFFD73F0287BC77D00D9F267 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -119,7 +117,6 @@
 				EFF8D2BA28819D03005A4D10 /* UIViewController+.swift */,
 				EFF8D2A528810A11005A4D10 /* UIView+.swift */,
 				EFF8D2A928811A7F005A4D10 /* UIStackView+.swift */,
-				EFF8D2B82881982A005A4D10 /* UIViewController+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";

--- a/Alarmi/Alarmi.xcodeproj/project.pbxproj
+++ b/Alarmi/Alarmi.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		EFF8D2BB28819D03005A4D10 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D2BA28819D03005A4D10 /* UIViewController+.swift */; };
 		EFF8D2A628810A11005A4D10 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D2A528810A11005A4D10 /* UIView+.swift */; };
 		EFF8D2AA28811A7F005A4D10 /* UIStackView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D2A928811A7F005A4D10 /* UIStackView+.swift */; };
+		EFF8D2B92881982A005A4D10 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D2B82881982A005A4D10 /* UIViewController+.swift */; };
 		EFFD73EF287BC77D00D9F267 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFFD73EE287BC77D00D9F267 /* AppDelegate.swift */; };
 		EFFD73F1287BC77D00D9F267 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFFD73F0287BC77D00D9F267 /* SceneDelegate.swift */; };
 		EFFD73F3287BC77D00D9F267 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFFD73F2287BC77D00D9F267 /* ViewController.swift */; };
@@ -52,6 +53,7 @@
 		EFF8D2BA28819D03005A4D10 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		EFF8D2A528810A11005A4D10 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		EFF8D2A928811A7F005A4D10 /* UIStackView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+.swift"; sourceTree = "<group>"; };
+		EFF8D2B82881982A005A4D10 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		EFFD73EB287BC77D00D9F267 /* Alarmi.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Alarmi.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EFFD73EE287BC77D00D9F267 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		EFFD73F0287BC77D00D9F267 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -117,6 +119,7 @@
 				EFF8D2BA28819D03005A4D10 /* UIViewController+.swift */,
 				EFF8D2A528810A11005A4D10 /* UIView+.swift */,
 				EFF8D2A928811A7F005A4D10 /* UIStackView+.swift */,
+				EFF8D2B82881982A005A4D10 /* UIViewController+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -349,6 +352,7 @@
 				EFFD73F3287BC77D00D9F267 /* ViewController.swift in Sources */,
 				EFFD73EF287BC77D00D9F267 /* AppDelegate.swift in Sources */,
 				EFF8D2BB28819D03005A4D10 /* UIViewController+.swift in Sources */,
+				EFF8D2B92881982A005A4D10 /* UIViewController+.swift in Sources */,
 				EFF8D29B2880F226005A4D10 /* TodayViewController.swift in Sources */,
 				EFF8D2A4288102B1005A4D10 /* RecordViewController.swift in Sources */,
 				EFF8D2A628810A11005A4D10 /* UIView+.swift in Sources */,

--- a/Alarmi/Alarmi.xcodeproj/project.pbxproj
+++ b/Alarmi/Alarmi.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		EFF8D2A12880F4FE005A4D10 /* UITabBarItem+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D2A02880F4FE005A4D10 /* UITabBarItem+.swift */; };
 		EFF8D2A4288102B1005A4D10 /* RecordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D2A3288102B1005A4D10 /* RecordViewController.swift */; };
 		EFF8D2BB28819D03005A4D10 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D2BA28819D03005A4D10 /* UIViewController+.swift */; };
+		EFF8D2A628810A11005A4D10 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D2A528810A11005A4D10 /* UIView+.swift */; };
+		EFF8D2AA28811A7F005A4D10 /* UIStackView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D2A928811A7F005A4D10 /* UIStackView+.swift */; };
 		EFFD73EF287BC77D00D9F267 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFFD73EE287BC77D00D9F267 /* AppDelegate.swift */; };
 		EFFD73F1287BC77D00D9F267 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFFD73F0287BC77D00D9F267 /* SceneDelegate.swift */; };
 		EFFD73F3287BC77D00D9F267 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFFD73F2287BC77D00D9F267 /* ViewController.swift */; };
@@ -48,6 +50,8 @@
 		EFF8D2A02880F4FE005A4D10 /* UITabBarItem+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+.swift"; sourceTree = "<group>"; };
 		EFF8D2A3288102B1005A4D10 /* RecordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewController.swift; sourceTree = "<group>"; };
 		EFF8D2BA28819D03005A4D10 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
+		EFF8D2A528810A11005A4D10 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
+		EFF8D2A928811A7F005A4D10 /* UIStackView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+.swift"; sourceTree = "<group>"; };
 		EFFD73EB287BC77D00D9F267 /* Alarmi.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Alarmi.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EFFD73EE287BC77D00D9F267 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		EFFD73F0287BC77D00D9F267 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -111,6 +115,8 @@
 			children = (
 				EFF8D2A02880F4FE005A4D10 /* UITabBarItem+.swift */,
 				EFF8D2BA28819D03005A4D10 /* UIViewController+.swift */,
+				EFF8D2A528810A11005A4D10 /* UIView+.swift */,
+				EFF8D2A928811A7F005A4D10 /* UIStackView+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -345,8 +351,10 @@
 				EFF8D2BB28819D03005A4D10 /* UIViewController+.swift in Sources */,
 				EFF8D29B2880F226005A4D10 /* TodayViewController.swift in Sources */,
 				EFF8D2A4288102B1005A4D10 /* RecordViewController.swift in Sources */,
+				EFF8D2A628810A11005A4D10 /* UIView+.swift in Sources */,
 				EFF8D2992880EFA0005A4D10 /* MainTabBarController.swift in Sources */,
 				EFF8D2A12880F4FE005A4D10 /* UITabBarItem+.swift in Sources */,
+				EFF8D2AA28811A7F005A4D10 /* UIStackView+.swift in Sources */,
 				EFFD73F1287BC77D00D9F267 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Alarmi/Alarmi.xcodeproj/project.pbxproj
+++ b/Alarmi/Alarmi.xcodeproj/project.pbxproj
@@ -12,9 +12,10 @@
 		EFF8D29B2880F226005A4D10 /* TodayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D29A2880F226005A4D10 /* TodayViewController.swift */; };
 		EFF8D2A12880F4FE005A4D10 /* UITabBarItem+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D2A02880F4FE005A4D10 /* UITabBarItem+.swift */; };
 		EFF8D2A4288102B1005A4D10 /* RecordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D2A3288102B1005A4D10 /* RecordViewController.swift */; };
-		EFF8D2BB28819D03005A4D10 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D2BA28819D03005A4D10 /* UIViewController+.swift */; };
 		EFF8D2A628810A11005A4D10 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D2A528810A11005A4D10 /* UIView+.swift */; };
 		EFF8D2AA28811A7F005A4D10 /* UIStackView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D2A928811A7F005A4D10 /* UIStackView+.swift */; };
+		EFF8D2BB28819D03005A4D10 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D2BA28819D03005A4D10 /* UIViewController+.swift */; };
+		EFF8D2BF2881D219005A4D10 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D2BE2881D219005A4D10 /* UILabel+.swift */; };
 		EFFD73EF287BC77D00D9F267 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFFD73EE287BC77D00D9F267 /* AppDelegate.swift */; };
 		EFFD73F1287BC77D00D9F267 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFFD73F0287BC77D00D9F267 /* SceneDelegate.swift */; };
 		EFFD73F3287BC77D00D9F267 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFFD73F2287BC77D00D9F267 /* ViewController.swift */; };
@@ -49,9 +50,10 @@
 		EFF8D29A2880F226005A4D10 /* TodayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayViewController.swift; sourceTree = "<group>"; };
 		EFF8D2A02880F4FE005A4D10 /* UITabBarItem+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+.swift"; sourceTree = "<group>"; };
 		EFF8D2A3288102B1005A4D10 /* RecordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewController.swift; sourceTree = "<group>"; };
-		EFF8D2BA28819D03005A4D10 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		EFF8D2A528810A11005A4D10 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		EFF8D2A928811A7F005A4D10 /* UIStackView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+.swift"; sourceTree = "<group>"; };
+		EFF8D2BA28819D03005A4D10 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
+		EFF8D2BE2881D219005A4D10 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
 		EFFD73EB287BC77D00D9F267 /* Alarmi.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Alarmi.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EFFD73EE287BC77D00D9F267 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		EFFD73F0287BC77D00D9F267 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -117,6 +119,7 @@
 				EFF8D2BA28819D03005A4D10 /* UIViewController+.swift */,
 				EFF8D2A528810A11005A4D10 /* UIView+.swift */,
 				EFF8D2A928811A7F005A4D10 /* UIStackView+.swift */,
+				EFF8D2BE2881D219005A4D10 /* UILabel+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -349,12 +352,12 @@
 				EFFD73F3287BC77D00D9F267 /* ViewController.swift in Sources */,
 				EFFD73EF287BC77D00D9F267 /* AppDelegate.swift in Sources */,
 				EFF8D2BB28819D03005A4D10 /* UIViewController+.swift in Sources */,
-				EFF8D2B92881982A005A4D10 /* UIViewController+.swift in Sources */,
 				EFF8D29B2880F226005A4D10 /* TodayViewController.swift in Sources */,
 				EFF8D2A4288102B1005A4D10 /* RecordViewController.swift in Sources */,
 				EFF8D2A628810A11005A4D10 /* UIView+.swift in Sources */,
 				EFF8D2992880EFA0005A4D10 /* MainTabBarController.swift in Sources */,
 				EFF8D2A12880F4FE005A4D10 /* UITabBarItem+.swift in Sources */,
+				EFF8D2BF2881D219005A4D10 /* UILabel+.swift in Sources */,
 				EFF8D2AA28811A7F005A4D10 /* UIStackView+.swift in Sources */,
 				EFFD73F1287BC77D00D9F267 /* SceneDelegate.swift in Sources */,
 			);

--- a/Alarmi/Alarmi/Sources/Global/Extensions/UILabel+.swift
+++ b/Alarmi/Alarmi/Sources/Global/Extensions/UILabel+.swift
@@ -1,0 +1,17 @@
+//
+//  UILabel+.swift
+//  Alarmi
+//
+//  Created by Woody on 2022/07/16.
+//  Copyright © 2022 MoTe. All rights reserved.
+//
+
+import UIKit
+
+extension UILabel {
+    func setDynamicFont(_ style: UIFont.TextStyle) {
+        self.font = UIFont.preferredFont(forTextStyle: style)
+        self.adjustsFontForContentSizeCategory = true
+        self.numberOfLines = 0
+    }
+}

--- a/Alarmi/Alarmi/Sources/Global/Extensions/UILabel+.swift
+++ b/Alarmi/Alarmi/Sources/Global/Extensions/UILabel+.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 extension UILabel {
+    
     func setDynamicFont(_ style: UIFont.TextStyle) {
         self.font = UIFont.preferredFont(forTextStyle: style)
         self.adjustsFontForContentSizeCategory = true

--- a/Alarmi/Alarmi/Sources/Global/Extensions/UIStackView+.swift
+++ b/Alarmi/Alarmi/Sources/Global/Extensions/UIStackView+.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 extension UIStackView {
-
+    
     func addArrangedSubviews(_ views: UIView...) {
         for view in views {
             addArrangedSubview(view)

--- a/Alarmi/Alarmi/Sources/Global/Extensions/UIStackView+.swift
+++ b/Alarmi/Alarmi/Sources/Global/Extensions/UIStackView+.swift
@@ -1,0 +1,18 @@
+//
+//  UIStackView+.swift
+//  Alarmi
+//
+//  Created by Woody on 2022/07/15.
+//  Copyright © 2022 MoTe. All rights reserved.
+//
+
+import UIKit
+
+extension UIStackView {
+
+    func addArrangedSubviews(_ views: UIView...) {
+        for view in views {
+            addArrangedSubview(view)
+        }
+    }
+}

--- a/Alarmi/Alarmi/Sources/Global/Extensions/UITabBarItem+.swift
+++ b/Alarmi/Alarmi/Sources/Global/Extensions/UITabBarItem+.swift
@@ -10,6 +10,11 @@ import UIKit
 
 extension UITabBarItem {
     
+    convenience init(title: String, imageName: String) {
+        let image = UIImage(systemName: imageName)
+        self.init(title: title, image: image, selectedImage: nil)
+    }
+    
     convenience init(item: MainTabBarController.TabItem) {
         let image = UIImage(systemName: item.imageName)
         self.init(title: item.title, image: image, selectedImage: nil)

--- a/Alarmi/Alarmi/Sources/Global/Extensions/UIView+.swift
+++ b/Alarmi/Alarmi/Sources/Global/Extensions/UIView+.swift
@@ -1,0 +1,18 @@
+//
+//  UIView+.swift
+//  Alarmi
+//
+//  Created by Woody on 2022/07/15.
+//  Copyright © 2022 MoTe. All rights reserved.
+//
+
+import UIKit
+
+extension UIView {
+
+    func addSubviews(_ views: UIView...) {
+        for view in views {
+            addSubview(view)
+        }
+    }
+}

--- a/Alarmi/Alarmi/Sources/Global/Extensions/UIView+.swift
+++ b/Alarmi/Alarmi/Sources/Global/Extensions/UIView+.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 extension UIView {
-
+    
     func addSubviews(_ views: UIView...) {
         for view in views {
             addSubview(view)

--- a/Alarmi/Alarmi/Sources/ViewControllers/MainTabBarController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/MainTabBarController.swift
@@ -8,30 +8,14 @@
 
 import UIKit
 
-class MainTabBarController: UITabBarController {
-
-    enum TabItem {
-        case today
-        case record
-
-        var title: String {
-            switch self {
-            case .today:
-                return "오늘"
-            case .record:
-                return "기록"
-            }
-        }
-
-        var imageName: String {
-            switch self {
-            case .today:
-                return "doc.text.image"
-            case .record:
-                return "calendar"
-            }
-        }
+extension UIViewController {
+    func wrappedByNavigationController() -> UINavigationController {
+        let navigationController = UINavigationController(rootViewController: self)
+        navigationController.navigationBar.prefersLargeTitles = true
+        return navigationController
     }
+}
+class MainTabBarController: UITabBarController {
 
     private let todayViewController: UINavigationController = {
         let todayViewController = TodayViewController()
@@ -59,7 +43,35 @@ class MainTabBarController: UITabBarController {
     }
 
     private func attribute() {
+        tabBar.isTranslucent = false
         tabBar.tintColor = .systemBlue
         tabBar.backgroundColor = .systemGroupedBackground
     }
+}
+
+extension MainTabBarController {
+
+    enum TabItem {
+        case today
+        case record
+
+        var title: String {
+            switch self {
+            case .today:
+                return "오늘"
+            case .record:
+                return "기록"
+            }
+        }
+
+        var imageName: String {
+            switch self {
+            case .today:
+                return "doc.text.image"
+            case .record:
+                return "calendar"
+            }
+        }
+    }
+
 }

--- a/Alarmi/Alarmi/Sources/ViewControllers/MainTabBarController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/MainTabBarController.swift
@@ -8,13 +8,6 @@
 
 import UIKit
 
-extension UIViewController {
-    func wrappedByNavigationController() -> UINavigationController {
-        let navigationController = UINavigationController(rootViewController: self)
-        navigationController.navigationBar.prefersLargeTitles = true
-        return navigationController
-    }
-}
 class MainTabBarController: UITabBarController {
 
     private let todayViewController: UINavigationController = {

--- a/Alarmi/Alarmi/Sources/ViewControllers/MainTabBarController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/MainTabBarController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class MainTabBarController: UITabBarController {
+final class MainTabBarController: UITabBarController {
 
     enum TabItem {
         case today

--- a/Alarmi/Alarmi/Sources/ViewControllers/MainTabBarController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/MainTabBarController.swift
@@ -10,6 +10,29 @@ import UIKit
 
 class MainTabBarController: UITabBarController {
 
+    enum TabItem {
+        case today
+        case record
+
+        var title: String {
+            switch self {
+            case .today:
+                return "오늘"
+            case .record:
+                return "기록"
+            }
+        }
+
+        var imageName: String {
+            switch self {
+            case .today:
+                return "doc.text.image"
+            case .record:
+                return "calendar"
+            }
+        }
+    }
+
     private let todayViewController: UINavigationController = {
         let todayViewController = TodayViewController()
         todayViewController.view.backgroundColor = .systemGroupedBackground
@@ -36,35 +59,7 @@ class MainTabBarController: UITabBarController {
     }
 
     private func attribute() {
-        tabBar.isTranslucent = false
         tabBar.tintColor = .systemBlue
         tabBar.backgroundColor = .systemGroupedBackground
     }
-}
-
-extension MainTabBarController {
-
-    enum TabItem {
-        case today
-        case record
-
-        var title: String {
-            switch self {
-            case .today:
-                return "오늘"
-            case .record:
-                return "기록"
-            }
-        }
-
-        var imageName: String {
-            switch self {
-            case .today:
-                return "doc.text.image"
-            case .record:
-                return "calendar"
-            }
-        }
-    }
-
 }

--- a/Alarmi/Alarmi/Sources/ViewControllers/RecordViewController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/RecordViewController.swift
@@ -12,6 +12,7 @@ class RecordViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
         attribute()
     }
 

--- a/Alarmi/Alarmi/Sources/ViewControllers/RecordViewController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/RecordViewController.swift
@@ -9,13 +9,12 @@
 import UIKit
 
 class RecordViewController: UIViewController {
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         attribute()
     }
-    
+
     private func attribute() {
         title = "기록"
     }

--- a/Alarmi/Alarmi/Sources/ViewControllers/RecordViewController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/RecordViewController.swift
@@ -9,13 +9,13 @@
 import UIKit
 
 class RecordViewController: UIViewController {
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         attribute()
     }
-
+    
     private func attribute() {
         title = "기록"
     }

--- a/Alarmi/Alarmi/Sources/ViewControllers/TodayViewController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/TodayViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 class TodayViewController: UIViewController {
 
     // MARK: View
+    
     private let stackView: UIStackView = {
         $0.translatesAutoresizingMaskIntoConstraints = false
         $0.axis = .vertical
@@ -24,14 +25,17 @@ class TodayViewController: UIViewController {
         $0.translatesAutoresizingMaskIntoConstraints = false
         $0.text = "마지막으로 전화한지 5일이 지났어요."
         $0.font = UIFont.preferredFont(forTextStyle: .title2)
+        $0.adjustsFontSizeToFitWidth = true
         return $0
     }(UILabel())
 
     private let subDescriptionLabel: UILabel = {
         $0.translatesAutoresizingMaskIntoConstraints = false
         $0.text = "2일 후면 전화하기로 한 날이에요."
-        $0.font = UIFont.preferredFont(forTextStyle: .body)
         $0.textColor = .secondaryLabel
+        $0.font = UIFont.preferredFont(forTextStyle: .body)
+        $0.adjustsFontSizeToFitWidth = true
+
         return $0
     }(UILabel())
 
@@ -48,7 +52,7 @@ class TodayViewController: UIViewController {
 
         var container = AttributeContainer()
         container.font = UIFont.preferredFont(forTextStyle: .footnote)
-        $0.configuration?.attributedTitle = AttributedString("이번 연락 미루기", attributes: container)
+        $0.configuration?.attributedTitle = AttributedString("이번 연락 미루기 ", attributes: container)
 
         return $0
     }(UIButton(configuration: .plain()))
@@ -58,10 +62,11 @@ class TodayViewController: UIViewController {
         $0.configuration?.baseBackgroundColor = .systemBlue
         $0.configuration?.titleAlignment = .center
         $0.configuration?.cornerStyle = .medium
+        $0.configuration?.contentInsets = NSDirectionalEdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16)
 
         var container = AttributeContainer()
         container.font = UIFont.preferredFont(forTextStyle: .body)
-        $0.configuration?.attributedTitle = AttributedString("오늘 전화 기록하기 ", attributes: container)
+        $0.configuration?.attributedTitle = AttributedString("오늘 전화 기록하기", attributes: container)
 
         return $0
     }(UIButton(configuration: .filled()))
@@ -89,13 +94,10 @@ class TodayViewController: UIViewController {
             stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16)
         ])
 
-        stackView.addArrangedSubviews(descriptionLabel, subDescriptionLabel, delayButton)
-
         NSLayoutConstraint.activate([
             callButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -16),
-            callButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 105),
-            callButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -105),
-            callButton.heightAnchor.constraint(equalToConstant: 64)
+            callButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            callButton.widthAnchor.constraint(lessThanOrEqualToConstant: UIScreen.main.bounds.width - 32)
         ])
     }
     

--- a/Alarmi/Alarmi/Sources/ViewControllers/TodayViewController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/TodayViewController.swift
@@ -24,8 +24,7 @@ class TodayViewController: UIViewController {
     private let descriptionLabel: UILabel = {
         $0.translatesAutoresizingMaskIntoConstraints = false
         $0.text = "마지막으로 전화한지 5일이 지났어요."
-        $0.font = UIFont.preferredFont(forTextStyle: .title2)
-        $0.adjustsFontForContentSizeCategory = true
+        $0.setDynamicFont(.title2)
         return $0
     }(UILabel())
 
@@ -33,9 +32,7 @@ class TodayViewController: UIViewController {
         $0.translatesAutoresizingMaskIntoConstraints = false
         $0.text = "2일 후면 전화하기로 한 날이에요."
         $0.textColor = .secondaryLabel
-        $0.font = UIFont.preferredFont(forTextStyle: .body)
-        $0.adjustsFontForContentSizeCategory = true
-
+        $0.setDynamicFont(.body)
         return $0
     }(UILabel())
 

--- a/Alarmi/Alarmi/Sources/ViewControllers/TodayViewController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/TodayViewController.swift
@@ -10,13 +10,108 @@ import UIKit
 
 class TodayViewController: UIViewController {
 
+    // MARK: View
+    private let stackView: UIStackView = {
+        $0.translatesAutoresizingMaskIntoConstraints = false
+        $0.axis = .vertical
+        $0.distribution = .fill
+        $0.alignment = .leading
+        $0.spacing = 8
+        return $0
+    }(UIStackView())
+
+    private let descriptionLabel: UILabel = {
+        $0.translatesAutoresizingMaskIntoConstraints = false
+        $0.text = "마지막으로 전화한지 5일이 지났어요."
+        $0.font = UIFont.preferredFont(forTextStyle: .title2)
+        return $0
+    }(UILabel())
+
+    private let subDescriptionLabel: UILabel = {
+        $0.translatesAutoresizingMaskIntoConstraints = false
+        $0.text = "2일 후면 전화하기로 한 날이에요."
+        $0.font = UIFont.preferredFont(forTextStyle: .body)
+        $0.textColor = .secondaryLabel
+        return $0
+    }(UILabel())
+
+    private let delayButton: UIButton = {
+        $0.translatesAutoresizingMaskIntoConstraints = false
+
+        let config = UIImage.SymbolConfiguration(font: UIFont.preferredFont(forTextStyle: .caption2))
+        let image = UIImage(systemName: "chevron.right", withConfiguration: config)
+        $0.configuration?.image = image
+        $0.configuration?.imagePlacement = .trailing
+        $0.configuration?.baseBackgroundColor = .systemBlue
+        $0.configuration?.titleAlignment = .leading
+        $0.configuration?.contentInsets = .zero
+
+        var container = AttributeContainer()
+        container.font = UIFont.preferredFont(forTextStyle: .footnote)
+        $0.configuration?.attributedTitle = AttributedString("이번 연락 미루기", attributes: container)
+
+        return $0
+    }(UIButton(configuration: .plain()))
+
+    private let callButton: UIButton = {
+        $0.translatesAutoresizingMaskIntoConstraints = false
+        $0.configuration?.baseBackgroundColor = .systemBlue
+        $0.configuration?.titleAlignment = .center
+        $0.configuration?.cornerStyle = .medium
+
+        var container = AttributeContainer()
+        container.font = UIFont.preferredFont(forTextStyle: .body)
+        $0.configuration?.attributedTitle = AttributedString("오늘 전화 기록하기 ", attributes: container)
+
+        return $0
+    }(UIButton(configuration: .filled()))
+
+    // MARK: Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
         
         attribute()
+        layout()
     }
 
+    // MARK: Method
+
     private func attribute() {
+        setupNavigationBar()
+    }
+
+    private func layout() {
+        view.addSubviews(stackView, callButton)
+
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16)
+        ])
+
+        stackView.addArrangedSubviews(descriptionLabel, subDescriptionLabel, delayButton)
+
+        NSLayoutConstraint.activate([
+            callButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -16),
+            callButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 105),
+            callButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -105),
+            callButton.heightAnchor.constraint(equalToConstant: 64)
+        ])
+    }
+    
+    private func setupNavigationBar() {
         title = "오늘"
+        let image = UIImage(systemName: "gearshape")
+        let barButton = UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(settingButtonTapped))
+        self.navigationItem.rightBarButtonItem = barButton
+    }
+}
+
+extension TodayViewController {
+
+    // MARK: Button Action
+
+    @objc private func settingButtonTapped() {
+        // TODO: 설정 화면으로 이동
     }
 }

--- a/Alarmi/Alarmi/Sources/ViewControllers/TodayViewController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/TodayViewController.swift
@@ -25,7 +25,7 @@ class TodayViewController: UIViewController {
         $0.translatesAutoresizingMaskIntoConstraints = false
         $0.text = "마지막으로 전화한지 5일이 지났어요."
         $0.font = UIFont.preferredFont(forTextStyle: .title2)
-        $0.adjustsFontSizeToFitWidth = true
+        $0.adjustsFontForContentSizeCategory = true
         return $0
     }(UILabel())
 
@@ -34,7 +34,7 @@ class TodayViewController: UIViewController {
         $0.text = "2일 후면 전화하기로 한 날이에요."
         $0.textColor = .secondaryLabel
         $0.font = UIFont.preferredFont(forTextStyle: .body)
-        $0.adjustsFontSizeToFitWidth = true
+        $0.adjustsFontForContentSizeCategory = true
 
         return $0
     }(UILabel())
@@ -94,6 +94,8 @@ class TodayViewController: UIViewController {
             stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16)
         ])
 
+        stackView.addArrangedSubviews(descriptionLabel, subDescriptionLabel, delayButton)
+        
         NSLayoutConstraint.activate([
             callButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -16),
             callButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),

--- a/Alarmi/Alarmi/Sources/ViewControllers/TodayViewController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/TodayViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class TodayViewController: UIViewController {
+final class TodayViewController: UIViewController {
 
     // MARK: View
     


### PR DESCRIPTION
## 이슈번호 
#8 

## 작업사항

스케치에 올라온 화면대로 개발하였습니다. 설정 버튼은 네비게이션바의 rightItem으로 구성하였습니다. 아보의 dynamic을 고려한 디자인 의도대로 iOS 텍스트 스타일을 그대로 적용하였고, 이미지에도 텍스트 스타일을 적용하였습니다. (해당 레퍼런스는 이슈 댓글에 달려있습니다.) 

디자인 수정사항이 생긴다면 이슈 새로 생성 후 반영하겠습니다.

## 스크린샷

| 작업 전 | 작업 후 |
| ----- | ----- | 
| <img src="https://user-images.githubusercontent.com/56102421/179156184-a46a0e8b-a067-4c17-957a-d870a8c9ebce.png" width="250"> | <img src="https://user-images.githubusercontent.com/56102421/179156192-dd492bec-fd47-4e9d-9b4f-38ae8fbca12e.png" width="250"> |



## 검토할 사항
- [x] 주석 제거
- [x] 피드백 반영 