### PR TITLE
[D-2] 초기 설정 완료 온보딩 화면 구현

### DIFF
--- a/Alarmi/.swiftlint.yml
+++ b/Alarmi/.swiftlint.yml
@@ -11,6 +11,9 @@ disabled_rules:
 
     # 강제 언래핑은 피해야합니다. https://realm.github.io/SwiftLint/force_unwrapping.html
     - force_unwrapping
+    
+    # 타입 이름에는 alphanumeric만 포함되어야 합니다. https://realm.github.io/SwiftLint/type_name.html
+    - type_name
 
 # Default가 비활성화인 규칙을 활성화시키기
 opt_in_rules:

--- a/Alarmi/Alarmi.xcodeproj/project.pbxproj
+++ b/Alarmi/Alarmi.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		507E6F3428826AD80086A4CE /* SettingCompleteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507E6F3328826AD80086A4CE /* SettingCompleteViewController.swift */; };
 		EF25AD20287BD05E0014B41B /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = EF25AD1F287BD05E0014B41B /* .swiftlint.yml */; };
 		EFF8D2992880EFA0005A4D10 /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D2982880EFA0005A4D10 /* MainTabBarController.swift */; };
 		EFF8D29B2880F226005A4D10 /* TodayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D29A2880F226005A4D10 /* TodayViewController.swift */; };
@@ -51,6 +52,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		507E6F3328826AD80086A4CE /* SettingCompleteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingCompleteViewController.swift; sourceTree = "<group>"; };
 		EF25AD1F287BD05E0014B41B /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		EFF8D2982880EFA0005A4D10 /* MainTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarController.swift; sourceTree = "<group>"; };
 		EFF8D29A2880F226005A4D10 /* TodayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayViewController.swift; sourceTree = "<group>"; };
@@ -114,6 +116,7 @@
 				EFF8D29A2880F226005A4D10 /* TodayViewController.swift */,
 				EFF8D2A3288102B1005A4D10 /* RecordViewController.swift */,
 				EFF8D2C92882BC6A005A4D10 /* CallDelayViewController.swift */,
+				507E6F3328826AD80086A4CE /* SettingCompleteViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -393,6 +396,7 @@
 			files = (
 				EFF8D2BD2881C9F1005A4D10 /* SettingNotifyViewController.swift in Sources */,
 				EFF8D2C428826931005A4D10 /* AlarmAgainSetView.swift in Sources */,
+				507E6F3428826AD80086A4CE /* SettingCompleteViewController.swift in Sources */,
 				EFFD73F3287BC77D00D9F267 /* ViewController.swift in Sources */,
 				EFFD73EF287BC77D00D9F267 /* AppDelegate.swift in Sources */,
 				EFF8D2C22881D3DE005A4D10 /* AlarmSetView.swift in Sources */,

--- a/Alarmi/Alarmi/Sources/Global/Extensions/UIViewController+.swift
+++ b/Alarmi/Alarmi/Sources/Global/Extensions/UIViewController+.swift
@@ -16,3 +16,25 @@ extension UIViewController {
         return navigationController
     }
 }
+
+#if DEBUG
+import SwiftUI
+
+extension UIViewController {
+
+    private struct Preview: UIViewControllerRepresentable {
+        let viewController: UIViewController
+
+        func makeUIViewController(context: Context) -> UIViewController {
+            return viewController
+        }
+
+        func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        }
+    }
+
+    func toPreview() -> some View {
+        Preview(viewController: self)
+    }
+}
+#endif

--- a/Alarmi/Alarmi/Sources/ViewControllers/SettingCompleteViewController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/SettingCompleteViewController.swift
@@ -45,21 +45,25 @@ final class SettingCompleteViewController: UIViewController {
         return $0
     }(UILabel())
     
-    private let startButton: UIButton = {
+    private lazy var startButton: UIButton = {
         $0.translatesAutoresizingMaskIntoConstraints = false
         $0.configuration?.baseBackgroundColor = .systemBlue
         $0.configuration?.titleAlignment = .center
         $0.configuration?.cornerStyle = .medium
         $0.configuration?.title = "시작"
+        $0.addAction(startButtonAction, for: .touchUpInside)
         return $0
     }(UIButton(configuration: .filled()))
+    
+    private lazy var startButtonAction = UIAction { _ in
+        // TODO: MainTabBarController로 이동
+    }
     
     // MARK: Life Cycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        view.backgroundColor = .systemGroupedBackground
         attribute()
         layout()
     }
@@ -67,10 +71,7 @@ final class SettingCompleteViewController: UIViewController {
     // MARK: Method
     
     private func attribute() {
-        let action = UIAction { _ in
-            // TODO: 메인 화면으로 이동
-        }
-        startButton.addAction(action, for: .touchUpInside)
+        view.backgroundColor = .systemGroupedBackground
     }
     
     private func layout() {
@@ -85,26 +86,15 @@ final class SettingCompleteViewController: UIViewController {
         NSLayoutConstraint.activate([
             descriptionStack.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             descriptionStack.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            descriptionStack.leadingAnchor.constraint(
-                equalTo: view.layoutMarginsGuide.leadingAnchor
-            ),
-            descriptionStack.trailingAnchor.constraint(
-                equalTo: view.layoutMarginsGuide.trailingAnchor
-            )
+            descriptionStack.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
+            descriptionStack.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor)
         ])
 
         NSLayoutConstraint.activate([
-            startButton.bottomAnchor.constraint(
-                equalTo: view.safeAreaLayoutGuide.bottomAnchor,
-                constant: -16
-            ),
+            startButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -16),
             startButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            startButton.leadingAnchor.constraint(
-                equalTo: view.layoutMarginsGuide.leadingAnchor
-            ),
-            startButton.trailingAnchor.constraint(
-                equalTo: view.layoutMarginsGuide.trailingAnchor
-            ),
+            startButton.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
+            startButton.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
             startButton.heightAnchor.constraint(equalToConstant: 64)
         ])
     }

--- a/Alarmi/Alarmi/Sources/ViewControllers/SettingCompleteViewController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/SettingCompleteViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class SettingCompleteViewController: UIViewController {
+final class SettingCompleteViewController: UIViewController {
     private let descriptionStack: UIStackView = {
         $0.translatesAutoresizingMaskIntoConstraints = false
         $0.axis = .vertical

--- a/Alarmi/Alarmi/Sources/ViewControllers/SettingCompleteViewController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/SettingCompleteViewController.swift
@@ -24,3 +24,15 @@ class SettingCompleteViewController: UIViewController {
         
     }
 }
+
+#if DEBUG
+import SwiftUI
+
+struct SettingCompleteViewController_Preview: PreviewProvider {
+    static var previews: some View {
+        SettingCompleteViewController()
+            .toPreview()
+            .ignoresSafeArea()
+    }
+}
+#endif

--- a/Alarmi/Alarmi/Sources/ViewControllers/SettingCompleteViewController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/SettingCompleteViewController.swift
@@ -83,8 +83,11 @@ final class SettingCompleteViewController: UIViewController {
         NSLayoutConstraint.activate([
             descriptionStack.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             descriptionStack.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            descriptionStack.widthAnchor.constraint(
-                lessThanOrEqualToConstant: UIScreen.main.bounds.width - 32
+            descriptionStack.leadingAnchor.constraint(
+                equalTo: view.layoutMarginsGuide.leadingAnchor
+            ),
+            descriptionStack.trailingAnchor.constraint(
+                equalTo: view.layoutMarginsGuide.trailingAnchor
             )
         ])
         NSLayoutConstraint.activate([

--- a/Alarmi/Alarmi/Sources/ViewControllers/SettingCompleteViewController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/SettingCompleteViewController.swift
@@ -75,11 +75,13 @@ final class SettingCompleteViewController: UIViewController {
     
     private func layout() {
         view.addSubviews(descriptionStack, startButton)
+
         descriptionStack.addArrangedSubviews(
             checkSymbol,
             primaryDescriptionLabel,
             secondaryDescriptionLabel
         )
+
         NSLayoutConstraint.activate([
             descriptionStack.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             descriptionStack.centerYAnchor.constraint(equalTo: view.centerYAnchor),
@@ -90,6 +92,7 @@ final class SettingCompleteViewController: UIViewController {
                 equalTo: view.layoutMarginsGuide.trailingAnchor
             )
         ])
+
         NSLayoutConstraint.activate([
             startButton.bottomAnchor.constraint(
                 equalTo: view.safeAreaLayoutGuide.bottomAnchor,

--- a/Alarmi/Alarmi/Sources/ViewControllers/SettingCompleteViewController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/SettingCompleteViewController.swift
@@ -9,6 +9,9 @@
 import UIKit
 
 final class SettingCompleteViewController: UIViewController {
+    
+    // MARK: View
+    
     private let descriptionStack: UIStackView = {
         $0.translatesAutoresizingMaskIntoConstraints = false
         $0.axis = .vertical
@@ -50,6 +53,8 @@ final class SettingCompleteViewController: UIViewController {
         $0.configuration?.title = "시작"
         return $0
     }(UIButton(configuration: .filled()))
+    
+    // MARK: Life Cycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -58,6 +63,8 @@ final class SettingCompleteViewController: UIViewController {
         attribute()
         layout()
     }
+    
+    // MARK: Method
     
     private func attribute() {
         let action = UIAction { _ in
@@ -93,6 +100,8 @@ final class SettingCompleteViewController: UIViewController {
         ])
     }
 }
+
+// MARK: - Preview
 
 #if DEBUG
 import SwiftUI

--- a/Alarmi/Alarmi/Sources/ViewControllers/SettingCompleteViewController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/SettingCompleteViewController.swift
@@ -96,8 +96,11 @@ final class SettingCompleteViewController: UIViewController {
                 constant: -16
             ),
             startButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            startButton.widthAnchor.constraint(
-                equalToConstant: UIScreen.main.bounds.width - 32
+            startButton.leadingAnchor.constraint(
+                equalTo: view.layoutMarginsGuide.leadingAnchor
+            ),
+            startButton.trailingAnchor.constraint(
+                equalTo: view.layoutMarginsGuide.trailingAnchor
             ),
             startButton.heightAnchor.constraint(equalToConstant: 64)
         ])

--- a/Alarmi/Alarmi/Sources/ViewControllers/SettingCompleteViewController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/SettingCompleteViewController.swift
@@ -1,0 +1,26 @@
+//
+//  SettingCompleteViewController.swift
+//  Alarmi
+//
+//  Created by 민채호 on 2022/07/16.
+//  Copyright © 2022 MoTe. All rights reserved.
+//
+
+import UIKit
+
+class SettingCompleteViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = .systemGroupedBackground
+    }
+    
+    private func attribute() {
+        
+    }
+    
+    private func layout() {
+        
+    }
+}

--- a/Alarmi/Alarmi/Sources/ViewControllers/SettingCompleteViewController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/SettingCompleteViewController.swift
@@ -9,19 +9,88 @@
 import UIKit
 
 class SettingCompleteViewController: UIViewController {
+    private let descriptionStack: UIStackView = {
+        $0.translatesAutoresizingMaskIntoConstraints = false
+        $0.axis = .vertical
+        $0.distribution = .fill
+        $0.alignment = .center
+        $0.spacing = 8
+        return $0
+    }(UIStackView())
+    
+    private let checkSymbol: UIImageView = {
+        $0.translatesAutoresizingMaskIntoConstraints = false
+        
+        let config = UIImage.SymbolConfiguration(font: UIFont.systemFont(ofSize: 100))
+        let image = UIImage(systemName: "checkmark.circle.fill", withConfiguration: config)
+        $0.image = image
+        return $0
+    }(UIImageView())
+    
+    private let primaryDescriptionLabel: UILabel = {
+        $0.translatesAutoresizingMaskIntoConstraints = false
+        $0.text = "모든 설정을 완료했어요."
+        $0.setDynamicFont(.title3)
+        return $0
+    }(UILabel())
+    
+    private let secondaryDescriptionLabel: UILabel = {
+        $0.translatesAutoresizingMaskIntoConstraints = false
+        $0.text = "목표일이 되면 부모님께 전화드리고\n기록을 남겨보세요."
+        $0.textAlignment = .center
+        $0.setDynamicFont(.title3)
+        return $0
+    }(UILabel())
+    
+    private let startButton: UIButton = {
+        $0.translatesAutoresizingMaskIntoConstraints = false
+        $0.configuration?.baseBackgroundColor = .systemBlue
+        $0.configuration?.titleAlignment = .center
+        $0.configuration?.cornerStyle = .medium
+        $0.configuration?.title = "시작"
+        return $0
+    }(UIButton(configuration: .filled()))
 
     override func viewDidLoad() {
         super.viewDidLoad()
         
         view.backgroundColor = .systemGroupedBackground
+        attribute()
+        layout()
     }
     
     private func attribute() {
-        
+        let action = UIAction { _ in
+            // TODO: 메인 화면으로 이동
+        }
+        startButton.addAction(action, for: .touchUpInside)
     }
     
     private func layout() {
-        
+        view.addSubviews(descriptionStack, startButton)
+        descriptionStack.addArrangedSubviews(
+            checkSymbol,
+            primaryDescriptionLabel,
+            secondaryDescriptionLabel
+        )
+        NSLayoutConstraint.activate([
+            descriptionStack.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            descriptionStack.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            descriptionStack.widthAnchor.constraint(
+                lessThanOrEqualToConstant: UIScreen.main.bounds.width - 32
+            )
+        ])
+        NSLayoutConstraint.activate([
+            startButton.bottomAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.bottomAnchor,
+                constant: -16
+            ),
+            startButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            startButton.widthAnchor.constraint(
+                equalToConstant: UIScreen.main.bounds.width - 32
+            ),
+            startButton.heightAnchor.constraint(equalToConstant: 64)
+        ])
     }
 }
 


### PR DESCRIPTION
## 이슈번호 
- #12 

## 작업사항
- 초기 설정 완료시 나오는 온보딩 화면을 구현했습니다.
- SwiftUI 프리뷰를 적용하기 위한 UIViewController extension을 추가했습니다.
- SwiftUI 프리뷰 구조체 이름에 언더바(_)가 들어갔을 때 빌드가 안되는 것을 없애기 위해 SwiftLint 파일을 수정했습니다.(type_name 규칙 비활성화)

## 스크린샷

| 작업 화면 | Dynamic Types 확인 |
|:---:|:---:|
|<img width="250" src="https://user-images.githubusercontent.com/75792767/179341453-8df57dc4-98b0-4a32-b773-4fa696e010cb.png">|<img width="250" alt="image" src="https://user-images.githubusercontent.com/75792767/179341700-d04c01da-2266-4729-9895-882bb6161a75.png">|

## 질문
- 코드 한 줄이 99자를 넘으면 안 된다는 컨벤션을 지키기 위해 오토레이아웃 부분을 파라미터 기준으로 줄바꿈했는데, 똑같은 오토레이아웃 코드인데도 어떤건 줄바꿈하지 않고 어떤건 줄바꿈하니까 오히려 더 지저분해보이는 느낌입니다. 다들 이에 대해 어떻게 생각하시나요?
- 여기에 쓰인 '시작' 버튼은 초기 설정에 계속 쓰여서 컴포넌트화 하는게 좋을 것 같은데, 제가 아직 UIKit에서 컴포넌트화 하는 법을 몰라서 하지 못했습니다. 혹시 어떻게 하는지 아는분 계신가요?

## 기타
- SwiftUI 프리뷰 사용에 참고한 레퍼런스를 이슈 댓글에 남겨놨습니다.

## 검토할 사항
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석 제거 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] develop에 머지하는지 확인
