### PR TITLE
[D0] 통화시간 화면 구성 #21

### DIFF
--- a/Alarmi/Alarmi.xcodeproj/project.pbxproj
+++ b/Alarmi/Alarmi.xcodeproj/project.pbxproj
@@ -552,7 +552,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = BQUJTNYMGY;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Alarmi/Resources/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -561,7 +561,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -582,7 +582,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = BQUJTNYMGY;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Alarmi/Resources/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -591,7 +591,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Alarmi/Alarmi.xcodeproj/project.pbxproj
+++ b/Alarmi/Alarmi.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0E1AAF4B28847FBF004E707A /* CallTimeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E1AAF4A28847FBF004E707A /* CallTimeViewController.swift */; };
+		0E1AAF4D28848046004E707A /* CallTime.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0E1AAF4C28848046004E707A /* CallTime.storyboard */; };
 		EF25AD20287BD05E0014B41B /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = EF25AD1F287BD05E0014B41B /* .swiftlint.yml */; };
 		EFF8D2992880EFA0005A4D10 /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D2982880EFA0005A4D10 /* MainTabBarController.swift */; };
 		EFF8D29B2880F226005A4D10 /* TodayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFF8D29A2880F226005A4D10 /* TodayViewController.swift */; };
@@ -45,6 +47,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0E1AAF4A28847FBF004E707A /* CallTimeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallTimeViewController.swift; sourceTree = "<group>"; };
+		0E1AAF4C28848046004E707A /* CallTime.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CallTime.storyboard; sourceTree = "<group>"; };
 		EF25AD1F287BD05E0014B41B /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		EFF8D2982880EFA0005A4D10 /* MainTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarController.swift; sourceTree = "<group>"; };
 		EFF8D29A2880F226005A4D10 /* TodayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayViewController.swift; sourceTree = "<group>"; };
@@ -94,9 +98,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0E1AAF4928847F98004E707A /* SettingCallTimeViewController */ = {
+			isa = PBXGroup;
+			children = (
+				0E1AAF4A28847FBF004E707A /* CallTimeViewController.swift */,
+				0E1AAF4C28848046004E707A /* CallTime.storyboard */,
+			);
+			path = SettingCallTimeViewController;
+			sourceTree = "<group>";
+		};
 		EFF8D2972880EF81005A4D10 /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
+				0E1AAF4928847F98004E707A /* SettingCallTimeViewController */,
 				EFF8D2982880EFA0005A4D10 /* MainTabBarController.swift */,
 				EFF8D29A2880F226005A4D10 /* TodayViewController.swift */,
 				EFF8D2A3288102B1005A4D10 /* RecordViewController.swift */,
@@ -300,6 +314,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0E1AAF4D28848046004E707A /* CallTime.storyboard in Resources */,
 				EF25AD20287BD05E0014B41B /* .swiftlint.yml in Resources */,
 				EFFD73FB287BC77E00D9F267 /* LaunchScreen.storyboard in Resources */,
 				EFFD73F8287BC77E00D9F267 /* Assets.xcassets in Resources */,
@@ -350,6 +365,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EFFD73F3287BC77D00D9F267 /* ViewController.swift in Sources */,
+				0E1AAF4B28847FBF004E707A /* CallTimeViewController.swift in Sources */,
 				EFFD73EF287BC77D00D9F267 /* AppDelegate.swift in Sources */,
 				EFF8D2BB28819D03005A4D10 /* UIViewController+.swift in Sources */,
 				EFF8D29B2880F226005A4D10 /* TodayViewController.swift in Sources */,
@@ -536,6 +552,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = BQUJTNYMGY;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Alarmi/Resources/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -544,6 +561,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -564,6 +582,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = BQUJTNYMGY;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Alarmi/Resources/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -572,6 +591,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Alarmi/Alarmi/Sources/ViewControllers/SettingCallTimeViewController/CallTime.storyboard
+++ b/Alarmi/Alarmi/Sources/ViewControllers/SettingCallTimeViewController/CallTime.storyboard
@@ -8,22 +8,52 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
+        <!--View Controller-->
+        <scene sceneID="vqZ-tw-Pxi">
+            <objects>
+                <viewController id="IiP-Ok-5BZ" customClass="ViewController" customModule="MC3_Test2" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="yga-EF-FdK">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4wY-B0-Snv">
+                                <rect key="frame" x="173.5" y="432.5" width="67" height="31"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                                <connections>
+                                    <segue destination="yZ7-ft-2hv" kind="show" id="UKI-we-JwO"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="r0d-xh-sqY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="4wY-B0-Snv" firstAttribute="centerY" secondItem="yga-EF-FdK" secondAttribute="centerY" id="JdY-7Q-KB2"/>
+                            <constraint firstItem="4wY-B0-Snv" firstAttribute="centerX" secondItem="yga-EF-FdK" secondAttribute="centerX" id="UBF-Wi-V1Z"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="ocJ-RN-6xy"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="xwA-Ll-hEb" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="533" y="98"/>
+        </scene>
         <!--Call Time View Controller-->
         <scene sceneID="OEb-x8-QT7">
             <objects>
-                <viewController storyboardIdentifier="CallTimeViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="yZ7-ft-2hv" customClass="CallTimeViewController" customModule="Alarmi" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="yZ7-ft-2hv" customClass="CallTimeViewController" customModule="MC3_Test2" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="XeI-YG-Wpf">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="전화할 수 있는 시간대를 알려주세요." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jJm-7A-cNj">
-                                <rect key="frame" x="16" y="60" width="243" height="21"/>
+                                <rect key="frame" x="16" y="104" width="243" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wTm-xc-u2w">
-                                <rect key="frame" x="16" y="97" width="382" height="167"/>
+                                <rect key="frame" x="16" y="141" width="382" height="167"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="전화 가능 시간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SbY-wY-ZXI">
                                         <rect key="frame" x="16" y="16" width="124" height="26.5"/>
@@ -66,13 +96,13 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <datePicker verifyAmbiguity="off" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="time" minuteInterval="1" style="compact" translatesAutoresizingMaskIntoConstraints="NO" id="AOG-F6-Kcg">
-                                        <rect key="frame" x="224" y="73" width="88" height="31"/>
+                                        <rect key="frame" x="232.5" y="73" width="79.5" height="31"/>
                                         <connections>
                                             <action selector="endTimePickerAction:" destination="yZ7-ft-2hv" eventType="valueChanged" id="ViC-a4-iad"/>
                                         </connections>
                                     </datePicker>
                                     <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="한국은" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tag-bL-mDS">
-                                        <rect key="frame" x="224" y="58.5" width="88" height="14.5"/>
+                                        <rect key="frame" x="232.5" y="58.5" width="79.5" height="14.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -144,7 +174,25 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="VxZ-Tx-9MD" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1497" y="102"/>
+            <point key="canvasLocation" x="1346.376811594203" y="97.767857142857139"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="sFA-U9-IDh">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="miR-g1-Ez1" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="Hdn-Fu-2YO">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="IiP-Ok-5BZ" kind="relationship" relationship="rootViewController" id="tJ5-uz-dEg"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="w4J-JH-z9Z" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-300" y="98"/>
         </scene>
     </scenes>
     <resources>

--- a/Alarmi/Alarmi/Sources/ViewControllers/SettingCallTimeViewController/CallTime.storyboard
+++ b/Alarmi/Alarmi/Sources/ViewControllers/SettingCallTimeViewController/CallTime.storyboard
@@ -8,52 +8,22 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
-        <scene sceneID="vqZ-tw-Pxi">
-            <objects>
-                <viewController id="IiP-Ok-5BZ" customClass="ViewController" customModule="MC3_Test2" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="yga-EF-FdK">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4wY-B0-Snv">
-                                <rect key="frame" x="173.5" y="432.5" width="67" height="31"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="Button"/>
-                                <connections>
-                                    <segue destination="yZ7-ft-2hv" kind="show" id="UKI-we-JwO"/>
-                                </connections>
-                            </button>
-                        </subviews>
-                        <viewLayoutGuide key="safeArea" id="r0d-xh-sqY"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                        <constraints>
-                            <constraint firstItem="4wY-B0-Snv" firstAttribute="centerY" secondItem="yga-EF-FdK" secondAttribute="centerY" id="JdY-7Q-KB2"/>
-                            <constraint firstItem="4wY-B0-Snv" firstAttribute="centerX" secondItem="yga-EF-FdK" secondAttribute="centerX" id="UBF-Wi-V1Z"/>
-                        </constraints>
-                    </view>
-                    <navigationItem key="navigationItem" id="ocJ-RN-6xy"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="xwA-Ll-hEb" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="533" y="98"/>
-        </scene>
         <!--Call Time View Controller-->
         <scene sceneID="OEb-x8-QT7">
             <objects>
-                <viewController id="yZ7-ft-2hv" customClass="CallTimeViewController" customModule="MC3_Test2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="CallTimeViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="yZ7-ft-2hv" customClass="CallTimeViewController" customModule="Alarmi" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="XeI-YG-Wpf">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="전화할 수 있는 시간대를 알려주세요." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jJm-7A-cNj">
-                                <rect key="frame" x="16" y="104" width="243" height="21"/>
+                                <rect key="frame" x="16" y="60" width="243" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wTm-xc-u2w">
-                                <rect key="frame" x="16" y="141" width="382" height="167"/>
+                                <rect key="frame" x="16" y="97" width="382" height="167"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="전화 가능 시간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SbY-wY-ZXI">
                                         <rect key="frame" x="16" y="16" width="124" height="26.5"/>
@@ -96,13 +66,13 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <datePicker verifyAmbiguity="off" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="time" minuteInterval="1" style="compact" translatesAutoresizingMaskIntoConstraints="NO" id="AOG-F6-Kcg">
-                                        <rect key="frame" x="232.5" y="73" width="79.5" height="31"/>
+                                        <rect key="frame" x="224" y="73" width="88" height="31"/>
                                         <connections>
                                             <action selector="endTimePickerAction:" destination="yZ7-ft-2hv" eventType="valueChanged" id="ViC-a4-iad"/>
                                         </connections>
                                     </datePicker>
                                     <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="한국은" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tag-bL-mDS">
-                                        <rect key="frame" x="232.5" y="58.5" width="79.5" height="14.5"/>
+                                        <rect key="frame" x="224" y="58.5" width="88" height="14.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -174,25 +144,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="VxZ-Tx-9MD" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1346.376811594203" y="97.767857142857139"/>
-        </scene>
-        <!--Navigation Controller-->
-        <scene sceneID="sFA-U9-IDh">
-            <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="miR-g1-Ez1" sceneMemberID="viewController">
-                    <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="Hdn-Fu-2YO">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <nil name="viewControllers"/>
-                    <connections>
-                        <segue destination="IiP-Ok-5BZ" kind="relationship" relationship="rootViewController" id="tJ5-uz-dEg"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="w4J-JH-z9Z" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-300" y="98"/>
+            <point key="canvasLocation" x="1497" y="102"/>
         </scene>
     </scenes>
     <resources>

--- a/Alarmi/Alarmi/Sources/ViewControllers/SettingCallTimeViewController/CallTime.storyboard
+++ b/Alarmi/Alarmi/Sources/ViewControllers/SettingCallTimeViewController/CallTime.storyboard
@@ -47,18 +47,18 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="전화할 수 있는 시간대를 알려주세요." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jJm-7A-cNj">
-                                <rect key="frame" x="16" y="88" width="243" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="전화할 수 있는 시간대를 알려주세요." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jJm-7A-cNj">
+                                <rect key="frame" x="16" y="88" width="243" height="20.5"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wTm-xc-u2w">
-                                <rect key="frame" x="16" y="125" width="382" height="162.5"/>
+                                <rect key="frame" x="16" y="124.5" width="382" height="162.5"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="전화 가능 시간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SbY-wY-ZXI">
-                                        <rect key="frame" x="16" y="16" width="124" height="26.5"/>
-                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="전화 가능 시간" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SbY-wY-ZXI">
+                                        <rect key="frame" x="16" y="16" width="124.5" height="26.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
@@ -78,15 +78,15 @@
                                             <action selector="myLocationTimezoneSegmentedControlAction:" destination="yZ7-ft-2hv" eventType="valueChanged" id="CKp-uY-Yqa"/>
                                         </connections>
                                     </segmentedControl>
-                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="부터" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sd0-Qn-Q6U">
-                                        <rect key="frame" x="177" y="72" width="30" height="21"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="부터" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sd0-Qn-Q6U">
+                                        <rect key="frame" x="177" y="72" width="30" height="20.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="까지" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oov-Rx-grB">
-                                        <rect key="frame" x="320" y="72" width="30" height="21"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="까지" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oov-Rx-grB">
+                                        <rect key="frame" x="320.5" y="72" width="29.5" height="20.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
@@ -96,16 +96,16 @@
                                             <action selector="endTimePickerAction:" destination="yZ7-ft-2hv" eventType="valueChanged" id="ViC-a4-iad"/>
                                         </connections>
                                     </datePicker>
-                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="한국은" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tag-bL-mDS">
+                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="한국은" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tag-bL-mDS">
                                         <rect key="frame" x="223" y="50.5" width="89" height="14.5"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                        <nil key="textColor"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                        <color key="textColor" systemColor="secondaryLabelColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="한국은" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bvb-TR-st9">
+                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="한국은" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bvb-TR-st9">
                                         <rect key="frame" x="85" y="50.5" width="31.5" height="14.5"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                        <nil key="textColor"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                        <color key="textColor" systemColor="secondaryLabelColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
@@ -192,6 +192,9 @@
         </scene>
     </scenes>
     <resources>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="secondarySystemGroupedBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Alarmi/Alarmi/Sources/ViewControllers/SettingCallTimeViewController/CallTime.storyboard
+++ b/Alarmi/Alarmi/Sources/ViewControllers/SettingCallTimeViewController/CallTime.storyboard
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="vqZ-tw-Pxi">
+            <objects>
+                <viewController id="IiP-Ok-5BZ" customClass="ViewController" customModule="MC3_Test2" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="yga-EF-FdK">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4wY-B0-Snv">
+                                <rect key="frame" x="173.5" y="432.5" width="67" height="31"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                                <connections>
+                                    <segue destination="yZ7-ft-2hv" kind="show" id="UKI-we-JwO"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="r0d-xh-sqY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="4wY-B0-Snv" firstAttribute="centerY" secondItem="yga-EF-FdK" secondAttribute="centerY" id="JdY-7Q-KB2"/>
+                            <constraint firstItem="4wY-B0-Snv" firstAttribute="centerX" secondItem="yga-EF-FdK" secondAttribute="centerX" id="UBF-Wi-V1Z"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="ocJ-RN-6xy"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="xwA-Ll-hEb" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="533" y="98"/>
+        </scene>
+        <!--Call Time View Controller-->
+        <scene sceneID="OEb-x8-QT7">
+            <objects>
+                <viewController id="yZ7-ft-2hv" customClass="CallTimeViewController" customModule="MC3_Test2" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="XeI-YG-Wpf">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="전화할 수 있는 시간대를 알려주세요." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jJm-7A-cNj">
+                                <rect key="frame" x="16" y="104" width="243" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wTm-xc-u2w">
+                                <rect key="frame" x="16" y="141" width="382" height="167"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="전화 가능 시간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SbY-wY-ZXI">
+                                        <rect key="frame" x="16" y="16" width="124" height="26.5"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <datePicker verifyAmbiguity="off" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="time" minuteInterval="1" style="compact" translatesAutoresizingMaskIntoConstraints="NO" id="kXk-Fg-wcj">
+                                        <rect key="frame" x="78" y="73" width="99" height="31"/>
+                                        <connections>
+                                            <action selector="startTimePickerAction:" destination="yZ7-ft-2hv" eventType="valueChanged" id="tWt-Fk-J5r"/>
+                                        </connections>
+                                    </datePicker>
+                                    <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="azR-P9-8RU">
+                                        <rect key="frame" x="16" y="120" width="350" height="32"/>
+                                        <segments>
+                                            <segment title="쿠퍼티노 기준"/>
+                                            <segment title="한국 기준"/>
+                                        </segments>
+                                        <connections>
+                                            <action selector="myLocationTimezoneSegmentedControlAction:" destination="yZ7-ft-2hv" eventType="valueChanged" id="CKp-uY-Yqa"/>
+                                        </connections>
+                                    </segmentedControl>
+                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="부터" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sd0-Qn-Q6U">
+                                        <rect key="frame" x="177.5" y="78" width="30" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="까지" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oov-Rx-grB">
+                                        <rect key="frame" x="320" y="78" width="30" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="한국은" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bvb-TR-st9">
+                                        <rect key="frame" x="32" y="58.5" width="31.5" height="14.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <datePicker verifyAmbiguity="off" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="time" minuteInterval="1" style="compact" translatesAutoresizingMaskIntoConstraints="NO" id="AOG-F6-Kcg">
+                                        <rect key="frame" x="232.5" y="73" width="79.5" height="31"/>
+                                        <connections>
+                                            <action selector="endTimePickerAction:" destination="yZ7-ft-2hv" eventType="valueChanged" id="ViC-a4-iad"/>
+                                        </connections>
+                                    </datePicker>
+                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="한국은" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tag-bL-mDS">
+                                        <rect key="frame" x="232.5" y="58.5" width="79.5" height="14.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="AOG-F6-Kcg" firstAttribute="centerY" secondItem="kXk-Fg-wcj" secondAttribute="centerY" id="27z-Au-bY5"/>
+                                    <constraint firstItem="tag-bL-mDS" firstAttribute="leading" secondItem="AOG-F6-Kcg" secondAttribute="leading" id="33G-Kw-ZZg"/>
+                                    <constraint firstAttribute="trailing" secondItem="azR-P9-8RU" secondAttribute="trailing" constant="16" id="4zk-nY-lIq"/>
+                                    <constraint firstItem="tag-bL-mDS" firstAttribute="centerX" secondItem="AOG-F6-Kcg" secondAttribute="centerX" id="7xB-Qd-2Ch"/>
+                                    <constraint firstItem="AOG-F6-Kcg" firstAttribute="top" secondItem="tag-bL-mDS" secondAttribute="bottom" id="BAB-4K-ocq"/>
+                                    <constraint firstItem="bvb-TR-st9" firstAttribute="leading" secondItem="kXk-Fg-wcj" secondAttribute="leading" id="CTx-S9-55E"/>
+                                    <constraint firstItem="kXk-Fg-wcj" firstAttribute="top" secondItem="bvb-TR-st9" secondAttribute="bottom" id="CY5-vj-qRa"/>
+                                    <constraint firstItem="oov-Rx-grB" firstAttribute="centerY" secondItem="AOG-F6-Kcg" secondAttribute="centerY" id="DIb-3c-be8"/>
+                                    <constraint firstItem="oov-Rx-grB" firstAttribute="leading" secondItem="AOG-F6-Kcg" secondAttribute="trailing" constant="8" symbolic="YES" id="Jh5-IS-N0C"/>
+                                    <constraint firstAttribute="trailing" secondItem="oov-Rx-grB" secondAttribute="trailing" constant="32" id="KAD-8H-OUJ"/>
+                                    <constraint firstItem="tag-bL-mDS" firstAttribute="centerX" secondItem="AOG-F6-Kcg" secondAttribute="centerX" id="N5m-7Z-9Nu"/>
+                                    <constraint firstItem="Sd0-Qn-Q6U" firstAttribute="centerY" secondItem="kXk-Fg-wcj" secondAttribute="centerY" id="NKI-4v-Jyh"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="SbY-wY-ZXI" secondAttribute="trailing" id="Pfm-44-oRr"/>
+                                    <constraint firstItem="bvb-TR-st9" firstAttribute="leading" secondItem="wTm-xc-u2w" secondAttribute="leading" constant="32" id="Qrn-bU-CK7"/>
+                                    <constraint firstItem="tag-bL-mDS" firstAttribute="top" secondItem="SbY-wY-ZXI" secondAttribute="bottom" constant="16" id="SWc-bP-11T"/>
+                                    <constraint firstItem="azR-P9-8RU" firstAttribute="top" secondItem="kXk-Fg-wcj" secondAttribute="bottom" constant="16" id="UG7-D8-Mq7"/>
+                                    <constraint firstItem="SbY-wY-ZXI" firstAttribute="top" secondItem="wTm-xc-u2w" secondAttribute="top" constant="16" id="V2u-CT-tGW"/>
+                                    <constraint firstAttribute="bottom" secondItem="azR-P9-8RU" secondAttribute="bottom" constant="16" id="WW3-Oy-d2a"/>
+                                    <constraint firstItem="bvb-TR-st9" firstAttribute="top" secondItem="SbY-wY-ZXI" secondAttribute="bottom" constant="16" id="X85-XK-Emy"/>
+                                    <constraint firstItem="Sd0-Qn-Q6U" firstAttribute="leading" secondItem="kXk-Fg-wcj" secondAttribute="trailing" constant="8" symbolic="YES" id="aYC-0H-F9P"/>
+                                    <constraint firstItem="azR-P9-8RU" firstAttribute="leading" secondItem="wTm-xc-u2w" secondAttribute="leading" constant="16" id="jCI-Ky-f5f"/>
+                                    <constraint firstItem="bvb-TR-st9" firstAttribute="leading" secondItem="kXk-Fg-wcj" secondAttribute="leading" id="jiy-c5-92a"/>
+                                    <constraint firstItem="bvb-TR-st9" firstAttribute="leading" secondItem="kXk-Fg-wcj" secondAttribute="leading" id="nPm-b4-ru9"/>
+                                    <constraint firstItem="SbY-wY-ZXI" firstAttribute="leading" secondItem="wTm-xc-u2w" secondAttribute="leading" constant="16" id="rSB-Z4-b0I"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="15"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </view>
+                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6ue-bO-UKk">
+                                <rect key="frame" x="16" y="815" width="382" height="64"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="Button"/>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="QWX-nT-ug7"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="jJm-7A-cNj" firstAttribute="leading" secondItem="QWX-nT-ug7" secondAttribute="leading" constant="16" id="4Do-0U-tnD"/>
+                            <constraint firstItem="jJm-7A-cNj" firstAttribute="top" secondItem="QWX-nT-ug7" secondAttribute="top" constant="16" id="55c-fx-Zpr"/>
+                            <constraint firstItem="wTm-xc-u2w" firstAttribute="top" secondItem="jJm-7A-cNj" secondAttribute="bottom" constant="16" id="EIE-LJ-hCH"/>
+                            <constraint firstItem="6ue-bO-UKk" firstAttribute="leading" secondItem="QWX-nT-ug7" secondAttribute="leading" constant="16" id="GxO-Ga-bE6"/>
+                            <constraint firstItem="QWX-nT-ug7" firstAttribute="trailing" secondItem="6ue-bO-UKk" secondAttribute="trailing" constant="16" id="KE8-HA-dKH"/>
+                            <constraint firstItem="QWX-nT-ug7" firstAttribute="trailing" secondItem="wTm-xc-u2w" secondAttribute="trailing" constant="16" id="OIX-DI-eZP"/>
+                            <constraint firstItem="QWX-nT-ug7" firstAttribute="trailing" secondItem="wTm-xc-u2w" secondAttribute="trailing" constant="16" id="Qmd-N5-qzm"/>
+                            <constraint firstItem="QWX-nT-ug7" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="jJm-7A-cNj" secondAttribute="trailing" id="UZb-Nc-JiO"/>
+                            <constraint firstItem="wTm-xc-u2w" firstAttribute="leading" secondItem="QWX-nT-ug7" secondAttribute="leading" constant="16" id="fZR-7C-FoT"/>
+                            <constraint firstItem="6ue-bO-UKk" firstAttribute="bottom" secondItem="QWX-nT-ug7" secondAttribute="bottom" constant="-16" id="uLL-0G-mpF"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="8tf-xe-LTG"/>
+                    <connections>
+                        <outlet property="endTimePicker" destination="AOG-F6-Kcg" id="JZR-Kh-YKF"/>
+                        <outlet property="endTimeTransferredLabel" destination="tag-bL-mDS" id="Oou-9p-nmI"/>
+                        <outlet property="myLocationTimezoneSegmentedControl" destination="azR-P9-8RU" id="PUh-Si-TGC"/>
+                        <outlet property="startTimePicker" destination="kXk-Fg-wcj" id="dET-uq-4MO"/>
+                        <outlet property="startTimeTransferredLabel" destination="bvb-TR-st9" id="9xW-eJ-yXy"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="VxZ-Tx-9MD" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1346.376811594203" y="97.767857142857139"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="sFA-U9-IDh">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="miR-g1-Ez1" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="Hdn-Fu-2YO">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="IiP-Ok-5BZ" kind="relationship" relationship="rootViewController" id="tJ5-uz-dEg"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="w4J-JH-z9Z" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-300" y="98"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Alarmi/Alarmi/Sources/ViewControllers/SettingCallTimeViewController/CallTime.storyboard
+++ b/Alarmi/Alarmi/Sources/ViewControllers/SettingCallTimeViewController/CallTime.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21208.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21191"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -11,13 +12,13 @@
         <!--View Controller-->
         <scene sceneID="vqZ-tw-Pxi">
             <objects>
-                <viewController id="IiP-Ok-5BZ" customClass="ViewController" customModule="MC3_Test2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="IiP-Ok-5BZ" customClass="ViewController" customModule="Alarmi" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="yga-EF-FdK">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4wY-B0-Snv">
-                                <rect key="frame" x="173.5" y="432.5" width="67" height="31"/>
+                                <rect key="frame" x="169.5" y="431" width="75" height="34.5"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Button"/>
                                 <connections>
@@ -41,19 +42,19 @@
         <!--Call Time View Controller-->
         <scene sceneID="OEb-x8-QT7">
             <objects>
-                <viewController id="yZ7-ft-2hv" customClass="CallTimeViewController" customModule="MC3_Test2" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="CallTimeViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="yZ7-ft-2hv" customClass="CallTimeViewController" customModule="Alarmi" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="XeI-YG-Wpf">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="전화할 수 있는 시간대를 알려주세요." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jJm-7A-cNj">
-                                <rect key="frame" x="16" y="104" width="243" height="21"/>
+                                <rect key="frame" x="16" y="88" width="243" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wTm-xc-u2w">
-                                <rect key="frame" x="16" y="141" width="382" height="167"/>
+                                <rect key="frame" x="16" y="125" width="382" height="162.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="전화 가능 시간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SbY-wY-ZXI">
                                         <rect key="frame" x="16" y="16" width="124" height="26.5"/>
@@ -62,13 +63,13 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <datePicker verifyAmbiguity="off" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="time" minuteInterval="1" style="compact" translatesAutoresizingMaskIntoConstraints="NO" id="kXk-Fg-wcj">
-                                        <rect key="frame" x="78" y="73" width="99" height="31"/>
+                                        <rect key="frame" x="32" y="65" width="137" height="34.5"/>
                                         <connections>
                                             <action selector="startTimePickerAction:" destination="yZ7-ft-2hv" eventType="valueChanged" id="tWt-Fk-J5r"/>
                                         </connections>
                                     </datePicker>
                                     <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="azR-P9-8RU">
-                                        <rect key="frame" x="16" y="120" width="350" height="32"/>
+                                        <rect key="frame" x="16" y="115.5" width="350" height="32"/>
                                         <segments>
                                             <segment title="쿠퍼티노 기준"/>
                                             <segment title="한국 기준"/>
@@ -78,62 +79,58 @@
                                         </connections>
                                     </segmentedControl>
                                     <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="부터" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sd0-Qn-Q6U">
-                                        <rect key="frame" x="177.5" y="78" width="30" height="21"/>
+                                        <rect key="frame" x="177" y="72" width="30" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="까지" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oov-Rx-grB">
-                                        <rect key="frame" x="320" y="78" width="30" height="21"/>
+                                        <rect key="frame" x="320" y="72" width="30" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="한국은" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bvb-TR-st9">
-                                        <rect key="frame" x="32" y="58.5" width="31.5" height="14.5"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <datePicker verifyAmbiguity="off" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="time" minuteInterval="1" style="compact" translatesAutoresizingMaskIntoConstraints="NO" id="AOG-F6-Kcg">
-                                        <rect key="frame" x="232.5" y="73" width="79.5" height="31"/>
+                                    <datePicker verifyAmbiguity="off" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="time" minuteInterval="1" style="compact" translatesAutoresizingMaskIntoConstraints="NO" id="AOG-F6-Kcg">
+                                        <rect key="frame" x="223" y="65" width="89" height="34.5"/>
                                         <connections>
                                             <action selector="endTimePickerAction:" destination="yZ7-ft-2hv" eventType="valueChanged" id="ViC-a4-iad"/>
                                         </connections>
                                     </datePicker>
-                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="한국은" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tag-bL-mDS">
-                                        <rect key="frame" x="232.5" y="58.5" width="79.5" height="14.5"/>
+                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="한국은" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tag-bL-mDS">
+                                        <rect key="frame" x="223" y="50.5" width="89" height="14.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label verifyAmbiguity="off" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="한국은" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bvb-TR-st9">
+                                        <rect key="frame" x="85" y="50.5" width="31.5" height="14.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="backgroundColor" systemColor="secondarySystemGroupedBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="AOG-F6-Kcg" firstAttribute="centerY" secondItem="kXk-Fg-wcj" secondAttribute="centerY" id="27z-Au-bY5"/>
-                                    <constraint firstItem="tag-bL-mDS" firstAttribute="leading" secondItem="AOG-F6-Kcg" secondAttribute="leading" id="33G-Kw-ZZg"/>
                                     <constraint firstAttribute="trailing" secondItem="azR-P9-8RU" secondAttribute="trailing" constant="16" id="4zk-nY-lIq"/>
                                     <constraint firstItem="tag-bL-mDS" firstAttribute="centerX" secondItem="AOG-F6-Kcg" secondAttribute="centerX" id="7xB-Qd-2Ch"/>
                                     <constraint firstItem="AOG-F6-Kcg" firstAttribute="top" secondItem="tag-bL-mDS" secondAttribute="bottom" id="BAB-4K-ocq"/>
-                                    <constraint firstItem="bvb-TR-st9" firstAttribute="leading" secondItem="kXk-Fg-wcj" secondAttribute="leading" id="CTx-S9-55E"/>
                                     <constraint firstItem="kXk-Fg-wcj" firstAttribute="top" secondItem="bvb-TR-st9" secondAttribute="bottom" id="CY5-vj-qRa"/>
                                     <constraint firstItem="oov-Rx-grB" firstAttribute="centerY" secondItem="AOG-F6-Kcg" secondAttribute="centerY" id="DIb-3c-be8"/>
+                                    <constraint firstItem="kXk-Fg-wcj" firstAttribute="leading" secondItem="wTm-xc-u2w" secondAttribute="leading" constant="32" id="JUR-lZ-zuB"/>
                                     <constraint firstItem="oov-Rx-grB" firstAttribute="leading" secondItem="AOG-F6-Kcg" secondAttribute="trailing" constant="8" symbolic="YES" id="Jh5-IS-N0C"/>
                                     <constraint firstAttribute="trailing" secondItem="oov-Rx-grB" secondAttribute="trailing" constant="32" id="KAD-8H-OUJ"/>
-                                    <constraint firstItem="tag-bL-mDS" firstAttribute="centerX" secondItem="AOG-F6-Kcg" secondAttribute="centerX" id="N5m-7Z-9Nu"/>
                                     <constraint firstItem="Sd0-Qn-Q6U" firstAttribute="centerY" secondItem="kXk-Fg-wcj" secondAttribute="centerY" id="NKI-4v-Jyh"/>
-                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="SbY-wY-ZXI" secondAttribute="trailing" id="Pfm-44-oRr"/>
-                                    <constraint firstItem="bvb-TR-st9" firstAttribute="leading" secondItem="wTm-xc-u2w" secondAttribute="leading" constant="32" id="Qrn-bU-CK7"/>
-                                    <constraint firstItem="tag-bL-mDS" firstAttribute="top" secondItem="SbY-wY-ZXI" secondAttribute="bottom" constant="16" id="SWc-bP-11T"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="SbY-wY-ZXI" secondAttribute="trailing" constant="16" id="Pfm-44-oRr"/>
                                     <constraint firstItem="azR-P9-8RU" firstAttribute="top" secondItem="kXk-Fg-wcj" secondAttribute="bottom" constant="16" id="UG7-D8-Mq7"/>
                                     <constraint firstItem="SbY-wY-ZXI" firstAttribute="top" secondItem="wTm-xc-u2w" secondAttribute="top" constant="16" id="V2u-CT-tGW"/>
                                     <constraint firstAttribute="bottom" secondItem="azR-P9-8RU" secondAttribute="bottom" constant="16" id="WW3-Oy-d2a"/>
-                                    <constraint firstItem="bvb-TR-st9" firstAttribute="top" secondItem="SbY-wY-ZXI" secondAttribute="bottom" constant="16" id="X85-XK-Emy"/>
                                     <constraint firstItem="Sd0-Qn-Q6U" firstAttribute="leading" secondItem="kXk-Fg-wcj" secondAttribute="trailing" constant="8" symbolic="YES" id="aYC-0H-F9P"/>
+                                    <constraint firstItem="bvb-TR-st9" firstAttribute="centerX" secondItem="kXk-Fg-wcj" secondAttribute="centerX" id="heY-aB-7h4"/>
                                     <constraint firstItem="azR-P9-8RU" firstAttribute="leading" secondItem="wTm-xc-u2w" secondAttribute="leading" constant="16" id="jCI-Ky-f5f"/>
-                                    <constraint firstItem="bvb-TR-st9" firstAttribute="leading" secondItem="kXk-Fg-wcj" secondAttribute="leading" id="jiy-c5-92a"/>
-                                    <constraint firstItem="bvb-TR-st9" firstAttribute="leading" secondItem="kXk-Fg-wcj" secondAttribute="leading" id="nPm-b4-ru9"/>
                                     <constraint firstItem="SbY-wY-ZXI" firstAttribute="leading" secondItem="wTm-xc-u2w" secondAttribute="leading" constant="16" id="rSB-Z4-b0I"/>
+                                    <constraint firstItem="tag-bL-mDS" firstAttribute="top" secondItem="SbY-wY-ZXI" secondAttribute="bottom" constant="8" id="sUy-N6-b4m"/>
+                                    <constraint firstItem="bvb-TR-st9" firstAttribute="top" secondItem="SbY-wY-ZXI" secondAttribute="bottom" constant="8" id="t0v-bI-gKx"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
@@ -151,14 +148,13 @@
                         <viewLayoutGuide key="safeArea" id="QWX-nT-ug7"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="QWX-nT-ug7" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="jJm-7A-cNj" secondAttribute="trailing" constant="16" id="3Un-qd-NG2"/>
                             <constraint firstItem="jJm-7A-cNj" firstAttribute="leading" secondItem="QWX-nT-ug7" secondAttribute="leading" constant="16" id="4Do-0U-tnD"/>
-                            <constraint firstItem="jJm-7A-cNj" firstAttribute="top" secondItem="QWX-nT-ug7" secondAttribute="top" constant="16" id="55c-fx-Zpr"/>
+                            <constraint firstItem="jJm-7A-cNj" firstAttribute="top" secondItem="QWX-nT-ug7" secondAttribute="top" id="55c-fx-Zpr"/>
                             <constraint firstItem="wTm-xc-u2w" firstAttribute="top" secondItem="jJm-7A-cNj" secondAttribute="bottom" constant="16" id="EIE-LJ-hCH"/>
                             <constraint firstItem="6ue-bO-UKk" firstAttribute="leading" secondItem="QWX-nT-ug7" secondAttribute="leading" constant="16" id="GxO-Ga-bE6"/>
                             <constraint firstItem="QWX-nT-ug7" firstAttribute="trailing" secondItem="6ue-bO-UKk" secondAttribute="trailing" constant="16" id="KE8-HA-dKH"/>
                             <constraint firstItem="QWX-nT-ug7" firstAttribute="trailing" secondItem="wTm-xc-u2w" secondAttribute="trailing" constant="16" id="OIX-DI-eZP"/>
-                            <constraint firstItem="QWX-nT-ug7" firstAttribute="trailing" secondItem="wTm-xc-u2w" secondAttribute="trailing" constant="16" id="Qmd-N5-qzm"/>
-                            <constraint firstItem="QWX-nT-ug7" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="jJm-7A-cNj" secondAttribute="trailing" id="UZb-Nc-JiO"/>
                             <constraint firstItem="wTm-xc-u2w" firstAttribute="leading" secondItem="QWX-nT-ug7" secondAttribute="leading" constant="16" id="fZR-7C-FoT"/>
                             <constraint firstItem="6ue-bO-UKk" firstAttribute="bottom" secondItem="QWX-nT-ug7" secondAttribute="bottom" constant="-16" id="uLL-0G-mpF"/>
                         </constraints>
@@ -196,6 +192,9 @@
         </scene>
     </scenes>
     <resources>
+        <systemColor name="secondarySystemGroupedBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Alarmi/Alarmi/Sources/ViewControllers/SettingCallTimeViewController/CallTimeViewController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/SettingCallTimeViewController/CallTimeViewController.swift
@@ -1,0 +1,94 @@
+//
+//  CallTimeViewController.swift
+//  Alarmi
+//
+//  Created by kwon ji won on 2022/07/18.
+//  Copyright © 2022 MoTe. All rights reserved.
+//
+
+import UIKit
+
+class CallTimeViewController: UIViewController {
+
+    @IBOutlet weak var startTimePicker: UIDatePicker!
+    @IBOutlet weak var endTimePicker: UIDatePicker!
+    @IBOutlet weak var startTimeTransferredLabel: UILabel!
+    //위에 작게 보이는 변환된 시간
+    @IBOutlet weak var endTimeTransferredLabel: UILabel!
+    //위에 작게 보이는 변환된 시간
+    @IBOutlet weak var myLocationTimezoneSegmentedControl: UISegmentedControl!
+    //segmented control
+    
+    let myTimeZone: TimeZone! = TimeZone(identifier: "America/Los_Angeles")
+    let parentTimeZone: TimeZone! = TimeZone(identifier: "Asia/Seoul")
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureNavigationBar()
+        configureBackground()
+    }
+    
+    func configureNavigationBar() {
+        navigationController?.navigationBar.prefersLargeTitles = true
+        navigationController?.navigationBar.topItem?.title = "전화 시간"
+    }
+    
+    func configureBackground() {
+        view.backgroundColor = .systemGray6
+    }
+    
+    @IBAction func startTimePickerAction(_ sender: UIDatePicker) {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "a hh:mm"
+        
+        switch myLocationTimezoneSegmentedControl.selectedSegmentIndex {
+        case 0:
+            startTimePicker.timeZone = myTimeZone
+            dateFormatter.timeZone = parentTimeZone
+            let timeString = dateFormatter.string(from: sender.date)
+            startTimeTransferredLabel.text = "한국은 \(timeString)"
+            
+        case 1:
+            startTimePicker.timeZone = parentTimeZone
+            dateFormatter.timeZone = myTimeZone
+            let timeString = dateFormatter.string(from: sender.date)
+            startTimeTransferredLabel.text = "쿠퍼티노는 \(timeString)"
+        default : break
+        }
+    }
+    
+    @IBAction func endTimePickerAction(_ sender: UIDatePicker) {
+        
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "a hh:mm"
+        
+        switch myLocationTimezoneSegmentedControl.selectedSegmentIndex {
+        case 0:
+            endTimePicker.timeZone = myTimeZone
+            dateFormatter.timeZone = parentTimeZone
+            let timeString = dateFormatter.string(from: sender.date)
+            endTimeTransferredLabel.text = "한국은 \(timeString)"
+            
+        case 1:
+            endTimePicker.timeZone = parentTimeZone
+            dateFormatter.timeZone = myTimeZone
+            let timeString = dateFormatter.string(from: sender.date)
+            endTimeTransferredLabel.text = "쿠퍼티노는 \(timeString)"
+        default : break
+        }
+    }
+    
+    @IBAction func myLocationTimezoneSegmentedControlAction(_ sender: UISegmentedControl) {
+        switch sender.selectedSegmentIndex {
+        case 0:
+            startTimeTransferredLabel.text = "한국은"
+            endTimeTransferredLabel.text = "한국은"
+        case 1:
+            startTimeTransferredLabel.text = "쿠퍼티노는"
+            endTimeTransferredLabel.text = "쿠퍼티노는"
+        default : break
+        }
+    }
+
+}
+

--- a/Alarmi/Alarmi/Sources/ViewControllers/SettingCallTimeViewController/CallTimeViewController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/SettingCallTimeViewController/CallTimeViewController.swift
@@ -13,29 +13,27 @@ class CallTimeViewController: UIViewController {
     @IBOutlet weak var startTimePicker: UIDatePicker!
     @IBOutlet weak var endTimePicker: UIDatePicker!
     @IBOutlet weak var startTimeTransferredLabel: UILabel!
+    //위에 작게 보이는 변환된 시간
     @IBOutlet weak var endTimeTransferredLabel: UILabel!
+    //위에 작게 보이는 변환된 시간
     @IBOutlet weak var myLocationTimezoneSegmentedControl: UISegmentedControl!
+    //segmented control
     
     let myTimeZone: TimeZone! = TimeZone(identifier: "America/Los_Angeles")
     let parentTimeZone: TimeZone! = TimeZone(identifier: "Asia/Seoul")
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        attribute()
-    }
-    
-    private func attribute() {
         configureNavigationBar()
         configureBackground()
     }
     
-    private func configureNavigationBar() {
+    func configureNavigationBar() {
         navigationController?.navigationBar.prefersLargeTitles = true
         navigationController?.navigationBar.topItem?.title = "전화 시간"
     }
     
-    private func configureBackground() {
+    func configureBackground() {
         view.backgroundColor = .systemGray6
     }
     
@@ -49,6 +47,7 @@ class CallTimeViewController: UIViewController {
             dateFormatter.timeZone = parentTimeZone
             let timeString = dateFormatter.string(from: sender.date)
             startTimeTransferredLabel.text = "한국은 \(timeString)"
+            
         case 1:
             startTimePicker.timeZone = parentTimeZone
             dateFormatter.timeZone = myTimeZone
@@ -69,6 +68,7 @@ class CallTimeViewController: UIViewController {
             dateFormatter.timeZone = parentTimeZone
             let timeString = dateFormatter.string(from: sender.date)
             endTimeTransferredLabel.text = "한국은 \(timeString)"
+            
         case 1:
             endTimePicker.timeZone = parentTimeZone
             dateFormatter.timeZone = myTimeZone

--- a/Alarmi/Alarmi/Sources/ViewControllers/SettingCallTimeViewController/CallTimeViewController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/SettingCallTimeViewController/CallTimeViewController.swift
@@ -13,27 +13,29 @@ class CallTimeViewController: UIViewController {
     @IBOutlet weak var startTimePicker: UIDatePicker!
     @IBOutlet weak var endTimePicker: UIDatePicker!
     @IBOutlet weak var startTimeTransferredLabel: UILabel!
-    //위에 작게 보이는 변환된 시간
     @IBOutlet weak var endTimeTransferredLabel: UILabel!
-    //위에 작게 보이는 변환된 시간
     @IBOutlet weak var myLocationTimezoneSegmentedControl: UISegmentedControl!
-    //segmented control
     
     let myTimeZone: TimeZone! = TimeZone(identifier: "America/Los_Angeles")
     let parentTimeZone: TimeZone! = TimeZone(identifier: "Asia/Seoul")
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        attribute()
+    }
+    
+    private func attribute() {
         configureNavigationBar()
         configureBackground()
     }
     
-    func configureNavigationBar() {
+    private func configureNavigationBar() {
         navigationController?.navigationBar.prefersLargeTitles = true
         navigationController?.navigationBar.topItem?.title = "전화 시간"
     }
     
-    func configureBackground() {
+    private func configureBackground() {
         view.backgroundColor = .systemGray6
     }
     
@@ -47,7 +49,6 @@ class CallTimeViewController: UIViewController {
             dateFormatter.timeZone = parentTimeZone
             let timeString = dateFormatter.string(from: sender.date)
             startTimeTransferredLabel.text = "한국은 \(timeString)"
-            
         case 1:
             startTimePicker.timeZone = parentTimeZone
             dateFormatter.timeZone = myTimeZone
@@ -68,7 +69,6 @@ class CallTimeViewController: UIViewController {
             dateFormatter.timeZone = parentTimeZone
             let timeString = dateFormatter.string(from: sender.date)
             endTimeTransferredLabel.text = "한국은 \(timeString)"
-            
         case 1:
             endTimePicker.timeZone = parentTimeZone
             dateFormatter.timeZone = myTimeZone

--- a/Alarmi/Alarmi/Sources/ViewControllers/SettingCallTimeViewController/CallTimeViewController.swift
+++ b/Alarmi/Alarmi/Sources/ViewControllers/SettingCallTimeViewController/CallTimeViewController.swift
@@ -36,7 +36,7 @@ class CallTimeViewController: UIViewController {
     }
     
     private func configureBackground() {
-        view.backgroundColor = .systemGray6
+        view.backgroundColor = .systemGroupedBackground
     }
     
     @IBAction func startTimePickerAction(_ sender: UIDatePicker) {
@@ -54,7 +54,8 @@ class CallTimeViewController: UIViewController {
             dateFormatter.timeZone = myTimeZone
             let timeString = dateFormatter.string(from: sender.date)
             startTimeTransferredLabel.text = "쿠퍼티노는 \(timeString)"
-        default : break
+        default:
+            break
         }
     }
     
@@ -74,7 +75,8 @@ class CallTimeViewController: UIViewController {
             dateFormatter.timeZone = myTimeZone
             let timeString = dateFormatter.string(from: sender.date)
             endTimeTransferredLabel.text = "쿠퍼티노는 \(timeString)"
-        default : break
+        default:
+            break
         }
     }
     
@@ -86,7 +88,8 @@ class CallTimeViewController: UIViewController {
         case 1:
             startTimeTransferredLabel.text = "쿠퍼티노는"
             endTimeTransferredLabel.text = "쿠퍼티노는"
-        default : break
+        default :
+            break
         }
     }
 


### PR DESCRIPTION
## 이슈번호 
- #21 

## 작업사항
- CallTimeView부분을 작성 했습니다.
- 스토리 보드로 한 코드를 보니.. 못알아보겠군요 ㅜㅜ 
- 부모,자식 간 시간 조절을 가능하게 했습니다.
- 일단은 쿠퍼티노랑 한국기준으로 했어요!

- 우리하나 기준 오전, 오후로 기록이 되어 스케치와 다르게 디자인 됐습니다. 
- 쿠퍼티노는 TimeZone에 없어서 LA를 넣었습니다.
- 네비게이션 제목 설정이 잘 안되어서.. 일단 버튼으로 넣어놨는데.. 좀더 해봐야 할거같아요
- 버튼은 우디가 한거 쓸 예정입니다.

## 스크린샷

- UI 작업이었다면 개발 전과 후 화면을 캡처해서 올려주세요.


| 작업 전 | 작업 후 |
| ----- | ----- | 
<img width="250" alt="image" src="https://user-images.githubusercontent.com/102846055/179418903-3942048b-b8bc-491a-a0c6-7424c0d662cc.png">|<img width="250" alt="image" src="https://user-images.githubusercontent.com/102846055/179418884-356b4596-fbf3-47bc-981c-6987a774367e.png">|



## 검토할 사항
- [x] 전부다..?
- [x] 코드나 깃 잘 쓴게 맞는지 확인부탁합니다. 
