### PR TITLE
[D-1] 설정 화면 리팩토링 및 '앱 초기화' 추가

### DIFF
--- a/Alarmi/Alarmi/Sources/MainTab/Today/SettingViewController.swift
+++ b/Alarmi/Alarmi/Sources/MainTab/Today/SettingViewController.swift
@@ -83,8 +83,9 @@ extension SettingViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = UITableViewCell(style: .default, reuseIdentifier: .none)
+        let destructiveIndex = indexPath.row - defaultSettingList.count
         let isDestructive = indexPath.row < defaultSettingList.count
-        let text = isDestructive ? defaultSettingList[indexPath.row] : destructiveSettingList[indexPath.row - defaultSettingList.count]
+        let text = isDestructive ? defaultSettingList[indexPath.row] : destructiveSettingList[destructiveIndex]
         let textColor: UIColor = isDestructive ? .label : .systemRed
         let accessoryType: UITableViewCell.AccessoryType = isDestructive ? .disclosureIndicator : .none
         

--- a/Alarmi/Alarmi/Sources/MainTab/Today/SettingViewController.swift
+++ b/Alarmi/Alarmi/Sources/MainTab/Today/SettingViewController.swift
@@ -37,8 +37,8 @@ final class SettingViewController: UIViewController {
     
     // MARK: Property
     
-    private let defaultSettingList = ["나라 변경", "전화 시간 변경", "목표 변경", "알림 설정"]
-    private let destructiveSettingList = ["기록 초기화"]
+    private let defaultSettingList = ["전화 시간 변경", "목표 변경", "알림 설정"]
+    private let destructiveSettingList = ["기록 초기화", "앱 초기화"]
     
     // MARK: Life Cycle
 

--- a/Alarmi/Alarmi/Sources/MainTab/Today/SettingViewController.swift
+++ b/Alarmi/Alarmi/Sources/MainTab/Today/SettingViewController.swift
@@ -37,7 +37,8 @@ final class SettingViewController: UIViewController {
     
     // MARK: Property
     
-    private let settingList = ["나라 변경", "전화 시간 변경", "목표 변경", "알림 설정", "기록 초기화"]
+    private let defaultSettingList = ["나라 변경", "전화 시간 변경", "목표 변경", "알림 설정"]
+    private let destructiveSettingList = ["기록 초기화"]
     
     // MARK: Life Cycle
 
@@ -77,14 +78,15 @@ final class SettingViewController: UIViewController {
 extension SettingViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return settingList.count
+        return defaultSettingList.count + destructiveSettingList.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = UITableViewCell(style: .default, reuseIdentifier: .none)
-        let text = settingList[indexPath.row]
-        let textColor: UIColor = indexPath.row < 4 ? .label : .systemRed
-        let accessoryType: UITableViewCell.AccessoryType = indexPath.row < 4 ? .disclosureIndicator : .none
+        let isDestructive = indexPath.row < defaultSettingList.count
+        let text = isDestructive ? defaultSettingList[indexPath.row] : destructiveSettingList[indexPath.row - defaultSettingList.count]
+        let textColor: UIColor = isDestructive ? .label : .systemRed
+        let accessoryType: UITableViewCell.AccessoryType = isDestructive ? .disclosureIndicator : .none
         
         var content = cell.defaultContentConfiguration()
         content.text = text

--- a/Alarmi/Alarmi/Sources/MainTab/Today/SettingViewController.swift
+++ b/Alarmi/Alarmi/Sources/MainTab/Today/SettingViewController.swift
@@ -35,6 +35,20 @@ final class SettingViewController: UIViewController {
         preferredStyle: .alert
     ))
     
+    private let initializeAppAlert: UIAlertController = {
+        let eraseAction = UIAlertAction(title: "초기화", style: .destructive) { _ in
+            // TODO: 앱 초기화
+        }
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        $0.addAction(eraseAction)
+        $0.addAction(cancelAction)
+        return $0
+    }(UIAlertController(
+        title: "앱을 정말 초기화하시겠어요?",
+        message: "모든 설정과 기록이 삭제되며, 되돌릴 수 없습니다.",
+        preferredStyle: .alert
+    ))
+    
     // MARK: Property
     
     private let defaultSettingList = ["전화 시간 변경", "목표 변경", "알림 설정"]
@@ -108,8 +122,10 @@ extension SettingViewController: UITableViewDelegate {
         settingTableView.deselectRow(at: indexPath, animated: true)
         switch indexPath.row {
             // TODO: 각 설정 화면으로 내비게이션
-        case 4:
+        case 3:
             present(eraseRecordAlert, animated: true)
+        case 4:
+            present(initializeAppAlert, animated: true)
         default:
             break
         }


### PR DESCRIPTION
## 이슈번호 
- #51 

## 작업사항
- 설정 목록이 변경되어도 별도의 추가 작업 없이 내비게이션 설정인지, 파괴적 설정인지 나눠져서 표현되도록 했습니다.

    - `defaultSettingList`에 추가하면 회색 글자와 오른쪽 끝에 화살표가 있는 리스트로 추가됨
    - `destructiveSettingList`에 추가하면 빨간 글자에 화살표가 없는 리스트로 추가됨
- '앱 초기화' 설정 목록을 추가했습니다.
- enum을 사용하여 목록들을 관리하고 싶었으나 이건 포기했습니다. ㅠㅠ

## 스크린샷

| 작업 전 | 작업 후 |
| ----- | ----- | 
|<img width="250" src="https://user-images.githubusercontent.com/75792767/179355025-7e13188f-054f-4260-967a-c6132444e269.png">|<img width="250" alt="image" src="https://user-images.githubusercontent.com/75792767/179887202-a03cd572-4c46-44b9-aa75-d6e99d966db1.png">|

## 검토할 사항
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석 제거 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] develop에 머지하는지 확인
