### PR TITLE
[D-1] 알림 매니저 1차 구현

### DIFF
--- a/Alarmi/Alarmi/Sources/AppDelegate.swift
+++ b/Alarmi/Alarmi/Sources/AppDelegate.swift
@@ -11,7 +11,7 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        UNUserNotificationCenter.current().delegate = self
         return true
     }
 
@@ -28,5 +28,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
 }
+
+extension AppDelegate: UNUserNotificationCenterDelegate {
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                willPresent notification: UNNotification,
+                                withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler([.banner, .badge, .sound])
+    }
+ }

--- a/Alarmi/Alarmi/Sources/Register/RegisterNotifyViewController.swift
+++ b/Alarmi/Alarmi/Sources/Register/RegisterNotifyViewController.swift
@@ -129,13 +129,19 @@ final class RegisterNotifyViewController: UIViewController {
                 print(error)
             } else {
                 if granted {
+                    // TODO: 상황에 따른 content 변화 필요
                     let content = UNMutableNotificationContent()
                     content.title = "아직 전화하지 않았어요"
                     content.subtitle = "아들아 보고싶다!!!"
                     content.body = "전화한지 3일이 지났어요 ㅠㅠ 🥹"
                     content.badge = 1
-                    let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 5, repeats: false)
-                    let request = UNNotificationRequest(identifier: "Sample Notification", content: content, trigger: trigger)
+                    // TODO: startdate 목표시작일 받아와야 함
+                    let startDate = Date()
+                    let dateComponents = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: startDate)
+                    // TODO: repeat -> 알림 반복횟수
+                    // let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: false)
+                    let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 10, repeats: false)
+                    let request = UNNotificationRequest(identifier: "identifier", content: content, trigger: trigger)
                     self.notificationCenter.add(request, withCompletionHandler: nil)
                 } else {
                     print("Not Granted")

--- a/Alarmi/Alarmi/Sources/Register/RegisterNotifyViewController.swift
+++ b/Alarmi/Alarmi/Sources/Register/RegisterNotifyViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import UserNotifications
 
 protocol RegisterNotifyViewControllerDelegate: AnyObject {
     func gotoRegisterCompleteViewController()
@@ -51,6 +52,8 @@ final class RegisterNotifyViewController: UIViewController {
 
     weak var delegate: RegisterNotifyViewControllerDelegate?
 
+    private let notificationCenter = UNUserNotificationCenter.current()
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -61,6 +64,7 @@ final class RegisterNotifyViewController: UIViewController {
     private func attribute() {
         setup()
         setupNavigationBar()
+        generateUserNotification()
     }
 
     private func layout() {
@@ -117,6 +121,27 @@ final class RegisterNotifyViewController: UIViewController {
             self.alarmAgainSetDescriptionLabel.layer.opacity = opacity
             self.alarmAgainSetView.isUserInteractionEnabled = isUserInteractionEnabled
         }, completion: nil)
+    }
+
+    private func generateUserNotification() {
+        notificationCenter.requestAuthorization(options: [.alert, .badge, .sound]) { (granted, error) in
+            if let error = error {
+                print(error)
+            } else {
+                if granted {
+                    let content = UNMutableNotificationContent()
+                    content.title = "아직 전화하지 않았어요"
+                    content.subtitle = "아들아 보고싶다!!!"
+                    content.body = "전화한지 3일이 지났어요 ㅠㅠ 🥹"
+                    content.badge = 1
+                    let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 5, repeats: false)
+                    let request = UNNotificationRequest(identifier: "Sample Notification", content: content, trigger: trigger)
+                    self.notificationCenter.add(request, withCompletionHandler: nil)
+                } else {
+                    print("Not Granted")
+                }
+            }
+        }
     }
 
     @objc private func buttonDidTap() {


### PR DESCRIPTION
## 이슈번호 
- #48 

## 작업사항
- UserNotifications 를 사용해서 push 알림을 만들었습니다.
- TODO로 이후 작업해야할 사항을 표시해두었습니다.
- 지금 상황으로는 정해진 시간에 한번 뿌릴 수 있도록 작성할 수 있는데, push알림을 반복하기 위해서는 repeat 부분을 수정해야합니다. 일단 내일 있을 스프린트 리뷰와 빠른 스프린트 작업 진행을 위해 repeat부분은 제외한 채로 pr 날립니다. (그리즐리의 데이터 작업이 선행된 이후, 사용자가 설정한 '전화 주기'를 기준으로 repeat을 설정해야합니다.)

## 질문
- 혹시 push 알림 오는것에 대한 테스트는 어떻게 진행해야하나요? 저희는 사용자에게 입력받은 날짜 기준으로 알림을 주어야하기 때문에 주석처리되어있는 ```UNCalendarNotificationTrigger```를 사용해야하지만, push 알림이 정상적으로 뜨는지 확인하는 방법을 몰라서, 임시로 ```UNTimeIntervalNotificationTrigger```를 사용한 코드를 한 줄 더 추가해둔 상태입니다. 헤당 트리거는 'interval'를 초단위로 계산하여, 지금 작성된 코드 기준으로는 해당 페이지 런치 후 10초 뒤에 push알림이 뜨게끔 해둔 상황입니다.


## 스크린샷

| 사용자에게 권한 요청 | 알림이 뜨는 화면 |
| ----- | ----- | 
| ![alert](https://user-images.githubusercontent.com/96969693/179939381-48b2277b-c63c-437c-a256-9ddfae1efed9.gif)| ![푸시](https://user-images.githubusercontent.com/96969693/179939441-ddb35707-1c06-4577-bd53-6318bb728840.gif)|


## 검토할 사항
- [x] 주석처리된 부분은 추후 필요한 코드이니 신경쓰지 말아주세요!
- [x] 린트를 잘 지켜서 커밋하였는가
- [x] sceneDelegate는 커밋되지 않았는가
- [x] 컨벤션은 잘 지켜졌는가
