### PR TITLE
[D0] 한국 시간에 따른 앱 모드(라이트, 다크 모드) 변경

### DIFF
--- a/Alarmi/Alarmi.xcodeproj/project.pbxproj
+++ b/Alarmi/Alarmi.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		1537834E2884826900E173D1 /* SettingPlan.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1537834D2884826900E173D1 /* SettingPlan.storyboard */; };
 		385BB5562882BB270067AFF4 /* RegisterLocationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385BB5552882BB270067AFF4 /* RegisterLocationViewController.swift */; };
 		385BB5582882DF1D0067AFF4 /* RegisterLocationCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385BB5572882DF1D0067AFF4 /* RegisterLocationCollectionViewCell.swift */; };
+		5075907A28915CC50033C09B /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5075907928915CC50033C09B /* UIColor+.swift */; };
 		507E6F3428826AD80086A4CE /* RegisterCompleteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507E6F3328826AD80086A4CE /* RegisterCompleteViewController.swift */; };
 		507E6F362882D8A70086A4CE /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507E6F352882D8A70086A4CE /* SettingViewController.swift */; };
 		EF0C23D2288E232D00FF5A86 /* MoTeDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0C23D1288E232D00FF5A86 /* MoTeDate.swift */; };
@@ -71,6 +72,7 @@
 		1537834D2884826900E173D1 /* SettingPlan.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SettingPlan.storyboard; sourceTree = "<group>"; };
 		385BB5552882BB270067AFF4 /* RegisterLocationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterLocationViewController.swift; sourceTree = "<group>"; };
 		385BB5572882DF1D0067AFF4 /* RegisterLocationCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterLocationCollectionViewCell.swift; sourceTree = "<group>"; };
+		5075907928915CC50033C09B /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		507E6F3328826AD80086A4CE /* RegisterCompleteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterCompleteViewController.swift; sourceTree = "<group>"; };
 		507E6F352882D8A70086A4CE /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
 		EF0C23D1288E232D00FF5A86 /* MoTeDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoTeDate.swift; sourceTree = "<group>"; };
@@ -236,6 +238,7 @@
 				EFF8D2A928811A7F005A4D10 /* UIStackView+.swift */,
 				EFF8D2BE2881D219005A4D10 /* UILabel+.swift */,
 				EFF8D2D1288318CB005A4D10 /* UIFont+.swift */,
+				5075907928915CC50033C09B /* UIColor+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -506,6 +509,7 @@
 				EF3630F628866968007779C0 /* MainTabCoordinator.swift in Sources */,
 				EFF8D29B2880F226005A4D10 /* TodayViewController.swift in Sources */,
 				EFF8D2D2288318CB005A4D10 /* UIFont+.swift in Sources */,
+				5075907A28915CC50033C09B /* UIColor+.swift in Sources */,
 				EF0C23D2288E232D00FF5A86 /* MoTeDate.swift in Sources */,
 				EF3630F428866304007779C0 /* RegisterCoordinator.swift in Sources */,
 				EFF8D2A4288102B1005A4D10 /* RecordViewController.swift in Sources */,

--- a/Alarmi/Alarmi/Resources/Assets.xcassets/Background.colorset/Contents.json
+++ b/Alarmi/Alarmi/Resources/Assets.xcassets/Background.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x55",
-          "green" : "0x35",
-          "red" : "0x3F"
+          "blue" : "0xF4",
+          "green" : "0xF4",
+          "red" : "0xF4"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xD3",
-          "green" : "0x83",
-          "red" : "0x9C"
+          "blue" : "0x1E",
+          "green" : "0x1C",
+          "red" : "0x1C"
         }
       },
       "idiom" : "universal"

--- a/Alarmi/Alarmi/Resources/Assets.xcassets/CellBackground.colorset/Contents.json
+++ b/Alarmi/Alarmi/Resources/Assets.xcassets/CellBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2E",
+          "green" : "0x2C",
+          "red" : "0x2C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Alarmi/Alarmi/Resources/Assets.xcassets/GoalDateRed.colorset/Contents.json
+++ b/Alarmi/Alarmi/Resources/Assets.xcassets/GoalDateRed.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x55",
-          "green" : "0x35",
-          "red" : "0x3F"
+          "blue" : "0x2A",
+          "green" : "0x2A",
+          "red" : "0xB1"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xD3",
-          "green" : "0x83",
-          "red" : "0x9C"
+          "blue" : "0x4E",
+          "green" : "0x4E",
+          "red" : "0xC9"
         }
       },
       "idiom" : "universal"

--- a/Alarmi/Alarmi/Resources/Assets.xcassets/ToggleOrange.colorset/Contents.json
+++ b/Alarmi/Alarmi/Resources/Assets.xcassets/ToggleOrange.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x98",
+          "red" : "0xF3"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Alarmi/Alarmi/Sources/Global/Extensions/UIColor+.swift
+++ b/Alarmi/Alarmi/Sources/Global/Extensions/UIColor+.swift
@@ -1,0 +1,15 @@
+//
+//  UIColor+.swift
+//  Alarmi
+//
+//  Created by 민채호 on 2022/07/27.
+//  Copyright © 2022 MoTe. All rights reserved.
+//
+
+import UIKit
+
+extension UIColor {
+    static let backgroundColor = UIColor(named: "Background")
+    static let goalDateRed = UIColor(named: "GoalDateRed")
+    static let toggleOrange = UIColor(named: "ToggleOrange")
+}

--- a/Alarmi/Alarmi/Sources/Global/Extensions/UIColor+.swift
+++ b/Alarmi/Alarmi/Sources/Global/Extensions/UIColor+.swift
@@ -10,6 +10,7 @@ import UIKit
 
 extension UIColor {
     static let backgroundColor = UIColor(named: "Background")
+    static let cellBackgroundColor = UIColor(named: "CellBackground")
     static let goalDateRed = UIColor(named: "GoalDateRed")
     static let toggleOrange = UIColor(named: "ToggleOrange")
 }

--- a/Alarmi/Alarmi/Sources/SceneDelegate.swift
+++ b/Alarmi/Alarmi/Sources/SceneDelegate.swift
@@ -44,20 +44,23 @@ private extension SceneDelegate {
     func setLightOrDarkMode() {
         let calendar = Calendar.current
         let now = Date()
-
-        guard let midnight = calendar.date(
-            bySettingHour: 0,
+        
+        let deviceMidnightHour = getConvertedHour(koreaHour: 0)
+        let deviceAwakeHour = getConvertedHour(koreaHour: 7)
+        
+        let midnight = calendar.date(
+            bySettingHour: deviceMidnightHour,
             minute: 0,
             second: 0,
             of: now
-        ) else { return }
+        )!
 
-        guard let awakeTime = calendar.date(
-            bySettingHour: 7,
+        let awakeTime = calendar.date(
+            bySettingHour: deviceAwakeHour,
             minute: 0,
             second: 0,
             of: now
-        ) else { return }
+        )!
 
         let midnightCheckingTimer = Timer(
             fireAt: midnight,
@@ -79,6 +82,35 @@ private extension SceneDelegate {
 
         RunLoop.main.add(midnightCheckingTimer, forMode: .common)
         RunLoop.main.add(awakeTimeCheckingTimer, forMode: .common)
+    }
+    
+    func getConvertedHour(koreaHour hour: Int) -> Int {
+        let calendar = Calendar.current
+        let now = Date()
+        let currentYear = calendar.component(.year, from: now)
+        let currentMonth = calendar.component(.month, from: now)
+        let currentDay = calendar.component(.day, from: now)
+
+        let myTimeFormatter: DateFormatter = { formatter in
+            formatter.timeZone = TimeZone.autoupdatingCurrent
+            formatter.dateFormat = "YYYY-MM-dd HH:mm:ss"
+            return formatter
+        }(DateFormatter())
+
+        let koreaTimeZone = TimeZone(identifier: "Asia/Seoul")
+        let koreaMidnightComponents = DateComponents(
+            timeZone: koreaTimeZone,
+            year: currentYear,
+            month: currentMonth,
+            day: currentDay,
+            hour: hour,
+            minute: 0,
+            second: 0
+        )
+        let koreaMidnightDate = calendar.date(from: koreaMidnightComponents)!
+        let convertedDateString = myTimeFormatter.string(from: koreaMidnightDate)
+        let convertedDate = myTimeFormatter.date(from: convertedDateString)!
+        return calendar.component(.hour, from: convertedDate)
     }
     
     @objc func switchToDarkMode() {

--- a/Alarmi/Alarmi/Sources/SceneDelegate.swift
+++ b/Alarmi/Alarmi/Sources/SceneDelegate.swift
@@ -23,6 +23,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         coordinator?.start()
 
         window?.makeKeyAndVisible()
+        
+        setLightOrDarkMode()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {}
@@ -35,4 +37,55 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func sceneDidEnterBackground(_ scene: UIScene) {}
 
+}
+
+private extension SceneDelegate {
+
+    func setLightOrDarkMode() {
+        let calendar = Calendar.current
+        let now = Date()
+
+        guard let midnight = calendar.date(
+            bySettingHour: 0,
+            minute: 0,
+            second: 0,
+            of: now
+        ) else { return }
+
+        guard let awakeTime = calendar.date(
+            bySettingHour: 7,
+            minute: 0,
+            second: 0,
+            of: now
+        ) else { return }
+
+        let midnightCheckingTimer = Timer(
+            fireAt: midnight,
+            interval: 0,
+            target: self,
+            selector: #selector(switchToDarkMode),
+            userInfo: nil,
+            repeats: false
+        )
+        
+        let awakeTimeCheckingTimer = Timer(
+            fireAt: awakeTime,
+            interval: 0,
+            target: self,
+            selector: #selector(switchToLightMode),
+            userInfo: nil,
+            repeats: false
+        )
+
+        RunLoop.main.add(midnightCheckingTimer, forMode: .common)
+        RunLoop.main.add(awakeTimeCheckingTimer, forMode: .common)
+    }
+    
+    @objc func switchToDarkMode() {
+        window?.overrideUserInterfaceStyle = .dark
+    }
+    
+    @objc func switchToLightMode() {
+        window?.overrideUserInterfaceStyle = .light
+    }
 }

--- a/Alarmi/Alarmi/Sources/SceneDelegate.swift
+++ b/Alarmi/Alarmi/Sources/SceneDelegate.swift
@@ -93,7 +93,7 @@ private extension SceneDelegate {
 
         let myTimeFormatter: DateFormatter = { formatter in
             formatter.timeZone = TimeZone.autoupdatingCurrent
-            formatter.dateFormat = "YYYY-MM-dd HH:mm:ss"
+            formatter.dateFormat = "HH"
             return formatter
         }(DateFormatter())
 
@@ -109,8 +109,8 @@ private extension SceneDelegate {
         )
         let koreaMidnightDate = calendar.date(from: koreaMidnightComponents)!
         let convertedDateString = myTimeFormatter.string(from: koreaMidnightDate)
-        let convertedDate = myTimeFormatter.date(from: convertedDateString)!
-        return calendar.component(.hour, from: convertedDate)
+        let convertedHourInt = Int(convertedDateString)!
+        return convertedHourInt
     }
     
     @objc func switchToDarkMode() {


### PR DESCRIPTION
## 이슈번호 
- #77 

## 작업사항
- 한국 시간이 오전 0시가 되면 다크모드, 오전 7시가 되면 라이트모드가 되도록 했습니다.
- Assets에 색상을 추가하고, UIColor 익스텐션으로 만들었습니다.

## 설명
### `setLightOrDarkMode` 메서드
```swift
let midnightCheckingTimer = Timer(
    fireAt: midnight,
    interval: 0,
    target: self,
    selector: #selector(switchToDarkMode),
    userInfo: nil,
    repeats: false
)

let awakeTimeCheckingTimer = Timer(
    fireAt: awakeTime,
    interval: 0,
    target: self,
    selector: #selector(switchToLightMode),
    userInfo: nil,
    repeats: false
)

RunLoop.main.add(midnightCheckingTimer, forMode: .common)
RunLoop.main.add(awakeTimeCheckingTimer, forMode: .common)
```
메인 RunLoop에 Timer를 추가하여, 특정 시간(`fireAt`)에 함수를 호출(`selector`)하도록 했습니다.
(Special thanks to @deslog , @Lim-YongKwan 🙇‍♂️)

### `getConvertedHour` 메서드
```swift
let koreaMidnightComponents = DateComponents(
    timeZone: koreaTimeZone,
    year: currentYear,
    month: currentMonth,
    day: currentDay,
    hour: hour,
    minute: 0,
    second: 0
)
```
한국의 특정 시간(오전 0시와 7시)을 DateComponent로 만들고
-> Date로 변환
-> 디바이스의 TimeZone 시간으로 바뀐 String으로 변환 (DateFormatter 이용)
~-> Date로 변환~
~-> Hour 정보만 담은 Int 값을 반환~
~이라는 아주 복잡한 과정으로 만들게 됐는데, 더 쉬운 방법이 있으면 공유바랍니다(제발ㅠ).~

f163cb8 에서 수정했습니다.
한국 특정 시간 DateComponent
-> Date로 변환
-> 디바이스의 TimeZone 시간으로 바뀐 String으로 변환 (dateFormat = "HH" 사용하여 **시간만 불러옴**)
-> "HH"를 Int로 변환 (강제 언래핑...!!)
이전과 비교하여 디바이스 시간대 String을 Date로 변환하는 과정이 사라졌습니다.

## 질문
Date 타입을 전부 `!`으로 강제 언래핑했는데, 이래도 될까요?
원래 `guard let`을 사용하여 안전하게 언래핑하려 했는데, 라이트모드나 다크모드가 현재 시간에 따라 제대로 설정이 되지 않으면 어플에 심각한 오류(한국이 낮인데 다크모드가 보여지는 등)가 발생할 것 같아서 그냥 옵셔널이 발생하면 어플이 꺼지도록 강제 언래핑으로 남겼습니다.

## 검토할 사항
- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석 제거 확인
- [x] 컨벤션 지켰는지 확인
- [x] final, private 제대로 넣었는지 확인
- [x] develop에 머지하는지 확인