### PR TITLE
[D0] auto-assign -> CODEOWNERS로 변경 (리뷰어 자동추가 수정)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Example
+*.java @deslog @wody-d @wonny1012 @Chaeho-Min @Lim-YongKwan

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Example
-*.java @deslog @wody-d @wonny1012 @Chaeho-Min @Lim-YongKwan
+*.swift @deslog @wody-d @wonny1012 @Chaeho-Min @Lim-YongKwan

--- a/.github/auto-assign.yml
+++ b/.github/auto-assign.yml
@@ -7,10 +7,15 @@ addAssignees: false
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers:
   - Chaeho-Min
+  - Avo
   - deslog
+  - JI SOO
   - Lim-YongKwan
+  - Grizzly(Lim-YongKwan)
+  - wonny1012
   - wonny1012
   - wody-d
+  - Jaeyong
 # A list of keywords to be skipped the process that add reviewers if pull requests include it
 skipKeywords:
   - wip

--- a/Alarmi/Alarmi/Sources/MainTab/Today/TodayViewController.swift
+++ b/Alarmi/Alarmi/Sources/MainTab/Today/TodayViewController.swift
@@ -28,7 +28,7 @@ final class TodayViewController: UIViewController {
 
     private let descriptionLabel: UILabel = {
         $0.translatesAutoresizingMaskIntoConstraints = false
-        $0.text = "마지막으로 전화한지 5일이 지났어요."
+        $0.text = "마지막으로 전화한지 5일이 지났어요"
         $0.setDynamicFont(.title2)
         return $0
     }(UILabel())

--- a/Alarmi/Alarmi/Sources/MainTab/Today/TodayViewController.swift
+++ b/Alarmi/Alarmi/Sources/MainTab/Today/TodayViewController.swift
@@ -28,7 +28,7 @@ final class TodayViewController: UIViewController {
 
     private let descriptionLabel: UILabel = {
         $0.translatesAutoresizingMaskIntoConstraints = false
-        $0.text = "마지막으로 전화한지 5일이 지났어요"
+        $0.text = "마지막으로 전화한지 5일이 지났어요."
         $0.setDynamicFont(.title2)
         return $0
     }(UILabel())


### PR DESCRIPTION
## 이슈번호 
#79

### 💬 리뷰어 모두 수동으로 추가하시느라 고생하셨습니다,, 안되는 문제를 얼른 해결했어야 하는데ㅠ 막바지에 이렇게... 하지만 한번만이라도 편하게 해보자 하는 마인드로 그냥 해봣씁니다,, 늦어서 죄송합니다

## 작업사항
- auto assign이 적용되지 않아서 CODEOWNER 방법으로 바꿨습니다. (왜 안되는지 원인을 찾지 못했습니다,,)
- CODEOWNERS는 (지금 pr에도 자동등록 x) develop 브랜치 머지 후 하위브랜치에 대해서만 적용된다고합니다 ㅠㅠ 