### PR TITLE
✨ 코어 데이터 새로 생성

### DIFF
--- a/Alarmi/Alarmi.xcodeproj/project.pbxproj
+++ b/Alarmi/Alarmi.xcodeproj/project.pbxproj
@@ -9,6 +9,13 @@
 /* Begin PBXBuildFile section */
 		1537834C288480DE00E173D1 /* RegisterPlanViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1537834B288480DE00E173D1 /* RegisterPlanViewController.swift */; };
 		1537834E2884826900E173D1 /* SettingPlan.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1537834D2884826900E173D1 /* SettingPlan.storyboard */; };
+		15AD742628968E6700CE21E1 /* CreateCoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AD742528968E6700CE21E1 /* CreateCoreData.swift */; };
+		15AD742828968EF700CE21E1 /* ReadCoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AD742728968EF700CE21E1 /* ReadCoreData.swift */; };
+		15AD742A28968F0500CE21E1 /* SaveCoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AD742928968F0500CE21E1 /* SaveCoreData.swift */; };
+		15AD742C28968F4D00CE21E1 /* DeleteCoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AD742B28968F4D00CE21E1 /* DeleteCoreData.swift */; };
+		15AD742F28968FE300CE21E1 /* CoreDataModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 15AD742D28968FE300CE21E1 /* CoreDataModel.xcdatamodeld */; };
+		15AD74322896918900CE21E1 /* CoreDataDate+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AD74302896918900CE21E1 /* CoreDataDate+CoreDataClass.swift */; };
+		15AD74332896918900CE21E1 /* CoreDataDate+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AD74312896918900CE21E1 /* CoreDataDate+CoreDataProperties.swift */; };
 		3861D14D289229FD0001C187 /* TodayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3861D14C289229FD0001C187 /* TodayViewModel.swift */; };
 		3861D15C2892EA170001C187 /* TodayDdayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3861D15B2892EA170001C187 /* TodayDdayView.swift */; };
 		5075907A28915CC50033C09B /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5075907928915CC50033C09B /* UIColor+.swift */; };
@@ -92,6 +99,13 @@
 /* Begin PBXFileReference section */
 		1537834B288480DE00E173D1 /* RegisterPlanViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPlanViewController.swift; sourceTree = "<group>"; };
 		1537834D2884826900E173D1 /* SettingPlan.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SettingPlan.storyboard; sourceTree = "<group>"; };
+		15AD742528968E6700CE21E1 /* CreateCoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateCoreData.swift; sourceTree = "<group>"; };
+		15AD742728968EF700CE21E1 /* ReadCoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadCoreData.swift; sourceTree = "<group>"; };
+		15AD742928968F0500CE21E1 /* SaveCoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveCoreData.swift; sourceTree = "<group>"; };
+		15AD742B28968F4D00CE21E1 /* DeleteCoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteCoreData.swift; sourceTree = "<group>"; };
+		15AD742E28968FE300CE21E1 /* CoreDataModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = CoreDataModel.xcdatamodel; sourceTree = "<group>"; };
+		15AD74302896918900CE21E1 /* CoreDataDate+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoreDataDate+CoreDataClass.swift"; sourceTree = "<group>"; };
+		15AD74312896918900CE21E1 /* CoreDataDate+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoreDataDate+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		3861D14C289229FD0001C187 /* TodayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayViewModel.swift; sourceTree = "<group>"; };
 		3861D15B2892EA170001C187 /* TodayDdayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayDdayView.swift; sourceTree = "<group>"; };
 		5075907928915CC50033C09B /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
@@ -196,6 +210,20 @@
 				EF13EFA7289226A000BC8D49 /* Frequency.swift */,
 			);
 			path = Models;
+			sourceTree = "<group>";
+		};
+		15AD742428968E5C00CE21E1 /* CoreData */ = {
+			isa = PBXGroup;
+			children = (
+				15AD74302896918900CE21E1 /* CoreDataDate+CoreDataClass.swift */,
+				15AD74312896918900CE21E1 /* CoreDataDate+CoreDataProperties.swift */,
+				15AD742528968E6700CE21E1 /* CreateCoreData.swift */,
+				15AD742728968EF700CE21E1 /* ReadCoreData.swift */,
+				15AD742928968F0500CE21E1 /* SaveCoreData.swift */,
+				15AD742B28968F4D00CE21E1 /* DeleteCoreData.swift */,
+				15AD742D28968FE300CE21E1 /* CoreDataModel.xcdatamodeld */,
+			);
+			path = CoreData;
 			sourceTree = "<group>";
 		};
 		3861D15E28963A260001C187 /* SupportingViews */ = {
@@ -334,6 +362,7 @@
 		EFF8D29E2880F4F1005A4D10 /* Global */ = {
 			isa = PBXGroup;
 			children = (
+				15AD742428968E5C00CE21E1 /* CoreData */,
 				EF13EFE02892EBEB00BC8D49 /* Helper */,
 				EF13EFD32892B6A000BC8D49 /* Protocols */,
 				EF13EFCE2892B68000BC8D49 /* Manager */,
@@ -612,18 +641,22 @@
 				EF79623A289122C3009A176E /* RecordModel.swift in Sources */,
 				EFFD73EF287BC77D00D9F267 /* AppDelegate.swift in Sources */,
 				1537834C288480DE00E173D1 /* RegisterPlanViewController.swift in Sources */,
+				15AD742F28968FE300CE21E1 /* CoreDataModel.xcdatamodeld in Sources */,
 				50FACB04289560A90045BE01 /* AlarmSettingBoxView.swift in Sources */,
 				EF79623828911D06009A176E /* Constant.swift in Sources */,
 				EFF8D2C82882AE3A005A4D10 /* AMButton.swift in Sources */,
 				EF0C23D6288E234B00FF5A86 /* CallTime.swift in Sources */,
 				EF13EFD62892B6A000BC8D49 /* UserDefaultsManager.swift in Sources */,
+				15AD74332896918900CE21E1 /* CoreDataDate+CoreDataProperties.swift in Sources */,
 				EF0C23D6288E234B00FF5A86 /* CallTime.swift in Sources */,
 				3861D15C2892EA170001C187 /* TodayDdayView.swift in Sources */,
 				EF13EFAA28922EBB00BC8D49 /* Goal.swift in Sources */,
 				EF13EFD92892B6BA00BC8D49 /* CallDate.swift in Sources */,
 				EFF8D2BB28819D03005A4D10 /* UIViewController+.swift in Sources */,
 				EF13EFE62893685A00BC8D49 /* RegisterCallTimeViewModel.swift in Sources */,
+				15AD742A28968F0500CE21E1 /* SaveCoreData.swift in Sources */,
 				EF13EFE42892F85A00BC8D49 /* CallDateUserDefaults.swift in Sources */,
+				15AD74322896918900CE21E1 /* CoreDataDate+CoreDataClass.swift in Sources */,
 				EF13EFD72892B6A000BC8D49 /* Coordinator.swift in Sources */,
 				EF3630F628866968007779C0 /* MainTabCoordinator.swift in Sources */,
 				EFF8D29B2880F226005A4D10 /* TodayViewController.swift in Sources */,
@@ -646,12 +679,15 @@
 				50BC4AEA28928CCF00A2CDB5 /* SettingViewController.swift in Sources */,
 				50BC4AEB28928CCF00A2CDB5 /* SettingViewModel.swift in Sources */,
 				EF79622B2891042C009A176E /* RecordViewModel.swift in Sources */,
+				15AD742828968EF700CE21E1 /* ReadCoreData.swift in Sources */,
 				EFF8D2CA2882BC6A005A4D10 /* CallDelayViewController.swift in Sources */,
 				EF13EFA62891788500BC8D49 /* RecentAchieveContainerView.swift in Sources */,
 				EF13EFA8289226A000BC8D49 /* Frequency.swift in Sources */,
 				EF13EFDB2892CEF700BC8D49 /* UserDefaults+Codable.swift in Sources */,
 				EF79622A2891042C009A176E /* RecordViewController.swift in Sources */,
 				EF0C23D4288E234100FF5A86 /* Alarm.swift in Sources */,
+				15AD742628968E6700CE21E1 /* CreateCoreData.swift in Sources */,
+				15AD742C28968F4D00CE21E1 /* DeleteCoreData.swift in Sources */,
 				EFFD73F1287BC77D00D9F267 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -992,6 +1028,19 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		15AD742D28968FE300CE21E1 /* CoreDataModel.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				15AD742E28968FE300CE21E1 /* CoreDataModel.xcdatamodel */,
+			);
+			currentVersion = 15AD742E28968FE300CE21E1 /* CoreDataModel.xcdatamodel */;
+			path = CoreDataModel.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = EFFD73E3287BC77D00D9F267 /* Project object */;
 }

--- a/Alarmi/Alarmi/Sources/AppDelegate.swift
+++ b/Alarmi/Alarmi/Sources/AppDelegate.swift
@@ -4,8 +4,8 @@
 //
 //  Created by Woody on 2022/07/11.
 //
-
 import UIKit
+import CoreData
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -16,7 +16,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     // MARK: UISceneSession Lifecycle
-
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
@@ -27,6 +26,49 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+    
+    // MARK: - Core Data Stack
+    lazy var persistentContainer: NSPersistentContainer = {
+        /*
+         The persistent container for the application. This implementation
+         creates and returns a container, having loaded the store for the
+         application to it. This property is optional since there are legitimate
+         error conditions that could cause the creation of the store to fail.
+        */
+        let container = NSPersistentContainer(name: "CoreDataModel")
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                 
+                /*
+                 Typical reasons for an error here include:
+                 * The parent directory does not exist, cannot be created, or disallows writing.
+                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
+                 * The device is out of space.
+                 * The store could not be migrated to the current model version.
+                 Check the error message to determine what the actual problem was.
+                 */
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
+
+    // MARK: - Core Data Saving support
+    func saveContext () {
+        let context = persistentContainer.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+            }
+        }
     }
 
 }

--- a/Alarmi/Alarmi/Sources/Global/CoreData/CoreDataDate+CoreDataClass.swift
+++ b/Alarmi/Alarmi/Sources/Global/CoreData/CoreDataDate+CoreDataClass.swift
@@ -1,0 +1,16 @@
+//
+//  CoreDataDate+CoreDataClass.swift
+//  Alarmi
+//
+//  Created by 임 용관 on 2022/07/31.
+//  Copyright © 2022 MoTe. All rights reserved.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(CoreDataDate)
+public class CoreDataDate: NSManagedObject {
+
+}

--- a/Alarmi/Alarmi/Sources/Global/CoreData/CoreDataDate+CoreDataProperties.swift
+++ b/Alarmi/Alarmi/Sources/Global/CoreData/CoreDataDate+CoreDataProperties.swift
@@ -1,0 +1,27 @@
+//
+//  CoreDataDate+CoreDataProperties.swift
+//  Alarmi
+//
+//  Created by 임 용관 on 2022/07/31.
+//  Copyright © 2022 MoTe. All rights reserved.
+//
+//
+
+import Foundation
+import CoreData
+
+extension CoreDataDate {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<CoreDataDate> {
+        return NSFetchRequest<CoreDataDate>(entityName: "CoreDataDate")
+    }
+
+    @NSManaged public var callTimePeriod: Int16
+    @NSManaged public var callDate: [Date]?
+    @NSManaged public var id: UUID?
+
+}
+
+extension CoreDataDate: Identifiable {
+
+}

--- a/Alarmi/Alarmi/Sources/Global/CoreData/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
+++ b/Alarmi/Alarmi/Sources/Global/CoreData/CoreDataModel.xcdatamodeld/CoreDataModel.xcdatamodel/contents
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21E258" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="CoreDataDate" representedClassName="CoreDataDate" syncable="YES">
+        <attribute name="callDate" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromDataTransformer" customClassName="[Date]"/>
+        <attribute name="callTimePeriod" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+    </entity>
+    <elements>
+        <element name="CoreDataDate" positionX="-54" positionY="-9" width="128" height="74"/>
+    </elements>
+</model>

--- a/Alarmi/Alarmi/Sources/Global/CoreData/CreateCoreData.swift
+++ b/Alarmi/Alarmi/Sources/Global/CoreData/CreateCoreData.swift
@@ -1,0 +1,41 @@
+//
+//  SaveCoreData.swift
+//  Alarmi
+//
+//  Created by 임 용관 on 2022/07/29.
+//  Copyright © 2022 MoTe. All rights reserved.
+//
+import Foundation
+import CoreData
+import UIKit
+
+func createCoreData() -> Bool {
+    
+    // App Delegate 호출
+    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return false }
+
+    // App Delegate 내부에 있는 viewContext 호출
+    let context: NSManagedObjectContext = appDelegate.persistentContainer.viewContext
+
+    // managedContext 내부에 있는 entity 호출
+    let entity = NSEntityDescription.entity(forEntityName: "CoreDataDate", in: context)!
+
+    // entity 객체 생성
+    let object = NSManagedObject(entity: entity, insertInto: context)
+    
+    // 값 설정
+    object.setValue(UUID(), forKey: "id")
+    object.setValue(7, forKey: "callTimePeriod")
+    object.setValue([Date()], forKey: "callDate")
+    
+    do {
+        // managedContext 내부의 변경사항 저장
+        print("save")
+        try context.save()
+        return true
+    } catch let error as NSError {
+        // 에러 발생시
+        print("Could not save. \(error), \(error.userInfo)")
+        return false
+    }
+}

--- a/Alarmi/Alarmi/Sources/Global/CoreData/DeleteCoreData.swift
+++ b/Alarmi/Alarmi/Sources/Global/CoreData/DeleteCoreData.swift
@@ -1,0 +1,45 @@
+//
+//  DeleteCoreData.swift
+//  Alarmi
+//
+//  Created by 임 용관 on 2022/07/30.
+//  Copyright © 2022 MoTe. All rights reserved.
+//
+import Foundation
+import CoreData
+import UIKit
+
+func deleteCoreData(id: UUID) -> Bool {
+    
+    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return false }
+    let managedContext = appDelegate.persistentContainer.viewContext
+    let fetchRequest = NSFetchRequest<NSFetchRequestResult>.init(entityName: "CoreDataDate")
+    
+    // 아이디를 삭제 기준으로 설정
+    fetchRequest.predicate = NSPredicate(format: "id = %@", id.uuidString)
+    
+    do {
+        let result = try managedContext.fetch(fetchRequest)
+        let objectToDelete = result[0] as! NSManagedObject
+        managedContext.delete(objectToDelete)
+        try managedContext.save()
+        return true
+    } catch let error as NSError {
+        print("Could not update. \(error), \(error.userInfo)")
+        return false
+    }
+}
+
+// 코어 데이터 전부 삭제
+func resetAllRecords(in entity: String) // entity = Your_Entity_Name
+{
+    let context = ( UIApplication.shared.delegate as! AppDelegate ).persistentContainer.viewContext
+    let deleteFetch = NSFetchRequest<NSFetchRequestResult>(entityName: entity)
+    let deleteRequest = NSBatchDeleteRequest(fetchRequest: deleteFetch)
+    do {
+        try context.execute(deleteRequest)
+        try context.save()
+    } catch {
+        print("There was an error")
+    }
+}

--- a/Alarmi/Alarmi/Sources/Global/CoreData/ReadCoreData.swift
+++ b/Alarmi/Alarmi/Sources/Global/CoreData/ReadCoreData.swift
@@ -1,0 +1,32 @@
+//
+//  ReadCoreDate.swift
+//  Alarmi
+//
+//  Created by 임 용관 on 2022/07/30.
+//  Copyright © 2022 MoTe. All rights reserved.
+//
+import Foundation
+import CoreData
+import UIKit
+
+func readCoreData() -> [CoreDataDate] {
+
+    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return [] }
+    let context: NSManagedObjectContext = appDelegate.persistentContainer.viewContext
+    let request: NSFetchRequest<CoreDataDate> = CoreDataDate.fetchRequest()
+    request.sortDescriptors = [NSSortDescriptor(key: "callDate", ascending: true)]
+    
+    var items = [CoreDataDate]()
+    
+    do {
+        items = try context.fetch(request)
+    } catch {
+        print(error)
+    }
+    
+    for item in items {
+        print(item.callDate, terminator: " ")
+    }
+    
+    return items
+}

--- a/Alarmi/Alarmi/Sources/Global/CoreData/SaveCoreData.swift
+++ b/Alarmi/Alarmi/Sources/Global/CoreData/SaveCoreData.swift
@@ -1,0 +1,107 @@
+//
+//  UpdateCoreData.swift
+//  Alarmi
+//
+//  Created by 임 용관 on 2022/07/30.
+//  Copyright © 2022 MoTe. All rights reserved.
+//
+import Foundation
+import CoreData
+import UIKit
+
+func saveCoreData(day: Date, keyName: String) -> Bool {
+    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return false }
+    let managedContext = appDelegate.persistentContainer.viewContext
+    let fetchRequest = NSFetchRequest<NSFetchRequestResult>.init(entityName: "CoreDataDate")
+    
+    do {
+        let result = try managedContext.fetch(fetchRequest)
+        let object = result.last as! NSManagedObject
+        
+        object.setValue(day, forKey: keyName)
+
+        try managedContext.save()
+        
+        return true
+    } catch let error as NSError {
+        print("Could not update. \(error), \(error.userInfo)")
+        return false
+    }
+}
+
+func saveCoreData(period: Int16, keyName: String) -> Bool {
+    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return false }
+    let managedContext = appDelegate.persistentContainer.viewContext
+    let fetchRequest = NSFetchRequest<NSFetchRequestResult>.init(entityName: "CoreDataDate")
+    
+    do {
+        let result = try managedContext.fetch(fetchRequest)
+        let object = result.last as! NSManagedObject
+        
+        object.setValue(period, forKey: keyName)
+        
+        try managedContext.save()
+        return true
+    } catch let error as NSError {
+        print("Could not update. \(error), \(error.userInfo)")
+        return false
+    }
+}
+
+func saveCoreData(isCall: Bool, keyName: String) -> Bool {
+    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return false }
+    let managedContext = appDelegate.persistentContainer.viewContext
+    let fetchRequest = NSFetchRequest<NSFetchRequestResult>.init(entityName: "CoreDataDate")
+    
+    do {
+        let result = try managedContext.fetch(fetchRequest)
+        let object = result.last as! NSManagedObject
+        
+        object.setValue(isCall, forKey: keyName)
+        
+        try managedContext.save()
+        return true
+    } catch let error as NSError {
+        print("Could not update. \(error), \(error.userInfo)")
+        return false
+    }
+}
+
+func updateToday() -> Bool {
+    // Update 오늘 되도록
+    // 중복 배열 X
+    let day = Date()
+    let keyName = "callDate"
+    
+    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return false }
+    let managedContext = appDelegate.persistentContainer.viewContext
+    let fetchRequest = NSFetchRequest<NSFetchRequestResult>.init(entityName: "CoreDataDate")
+    
+    do {
+        let result = try managedContext.fetch(fetchRequest)
+        guard let object = result.last as? CoreDataDate else { return false }
+
+        if object.callDate == nil {
+            object.setValue([day], forKey: keyName)
+        } else {
+            guard var curDate = object.callDate else { return false }
+            
+            guard let lastDay = curDate.last else {return false}
+            let lastDayComponent = Calendar.current.dateComponents([.year, .month, .day], from: lastDay)
+            let todayComponent = Calendar.current.dateComponents([.year, .month, .day], from: Date())
+            if lastDayComponent == todayComponent {
+                print("Fail!")
+                return false
+            } else {
+                print("Success!")
+                curDate.append(day)
+                object.setValue(curDate, forKey: keyName)
+            }
+        }
+        try managedContext.save()
+        return true
+    } catch let error as NSError {
+        print("Could not update. \(error), \(error.userInfo)")
+        return false
+    }
+}


### PR DESCRIPTION
## 이슈번호 
- #82 

## 작업사항
### 코어데이터 사용법 한번씩만 읽어주세요
### Entity의 이름은 `CoreDataDate` 입니다. Attribute 내부는 기존의 변수이름들을 따와서 만들었고 moteDate는 Date 배열로 만들어놨습니다.
- User Default로 저장되던 부분을 모두 코어데이터로 바꿔야 했기에 기존에 저장되는 방식을 함수로 구현하고 해당 뷰에서 함수를 호출해서 쓰면 기능되도록 만들었습니다.
- 코어데이터 그룹 내부에 보면 크게 **Create / Read / Delete / Save 코어 데이터 4가지**로 구성이 되어있습니다. 대부분의 경우에는 Save를 쓰신다고 보시면 됩니다.

- DeleteCoreData : 내부에 보면 `deleteCoreData()` 와 `resetAllRecords()`가 있을 겁니다. 첫번째 함수는 혹시 모를 상황을 대비해서 만들어 두었으나 아마 대부분의 상황에서 쓰이지 않는다고 보시면 됩니다. 설정쪽에서 앱 설정 모두 초기화 기능을 구현하실때 `resetAllRecords(in entity: Entity)` 를 사용하시면 됩니다.

- CreateCoreData : 내부에 보면 `createCoreData` 함수가 있습니다. 이 함수는 설정 화면에서 제일 처음 분이 코어데이터를 생성하실때 쓰시면 됩니다.

- SaveCoreData : 안에 보시면 총 4가지 함수로 이루어져 있습니다. 그 중 3가지 함수는 `saveCoreData` 라는 이름에 안에 매개변수값만 바꿔서 사용이 가능하게 만들었고 마지막 하나 `updateToday` 는 메인 화면에서 사용하는 함수입니다. `saveCoreData(데이터이름: 데이터형태, keyName: "Attribute이름")` 에서 첫번째 매개변수에 맡으신 뷰에서 넣고 싶은 값을 입력하시고 두번째 변수에 해당 변수값이 넣어질 이름. 즉, 변수명을 String으로 적어주시면 됩니다. 또한, 두번째 함수인 `updateToday` 는 메인 버튼에서 클릭안에 넣으시면 오늘 눌려진 값인지 아닌지 확인을 한 후 눌려진 값이라면 Fail이 출력되고 처음 누른다면 Success가 뜨게 만들어져 있습니다.

- ReadCoreData : 작업 하는데 가장 오래 걸린 부분인데 확인 용도로만 이루어져 있어서 쓰실 일이 많지는 않을 겁니다. 만일 자신의 해당 값을 확인 하고 싶으신 분은 for 문 안에 `print(item.변수명)` 에 출력을 원하는 Attribute 이름을 적어주시면 됩니다.

## 스크린샷

| 작업 전 | 작업 후 |
| ----- | ----- | 
|      |   <img width="250" alt="스크린샷 2022-07-31 오전 12 19 10" src="https://user-images.githubusercontent.com/96565110/181921062-9f533ff9-8ddf-4d05-ad05-12563db873e6.png">    |
### 클릭하시면 커집니다.


## 검토할 사항
- [ ] 주석 제거.
- [ ]  final, private 제대로 넣었는지 확인
- [ ] 컨벤션 지켰는지 확인
- [x] 코어데이터 함수 이름 변경 완료 (7/31)
